### PR TITLE
Calibrate new plans immediately after creation

### DIFF
--- a/pete_e/application/orchestrator.py
+++ b/pete_e/application/orchestrator.py
@@ -1339,6 +1339,26 @@ class Orchestrator:
                 f"Successfully saved new plan with ID: {plan_id}", "INFO"
             )
 
+            try:
+                progression_decision = calibrate_plan_week(
+                    self.dal,
+                    plan_id=plan_id,
+                    week_number=1,
+                    persist=True,
+                )
+            except Exception as calibration_error:  # pragma: no cover - log only
+                log_utils.log_message(
+                    "Failed to calibrate week 1 for plan "
+                    f"{plan_id}: {calibration_error}",
+                    "ERROR",
+                )
+            else:
+                log_utils.log_message(
+                    "Applied progression calibration to week 1 for plan "
+                    f"{plan_id}: {progression_decision}",
+                    "INFO",
+                )
+
             # Refresh the plan view to include the new data
             self.dal.refresh_plan_view()
 


### PR DESCRIPTION
## Summary
- invoke progression calibration for week one immediately after building a new plan
- log both successful calibration decisions and failures without interrupting plan deployment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4c4dd3420832fbba214ea8bb4a0f2