### PR TITLE
Unify database connection URL retrieval

### DIFF
--- a/pete_e/cli/messenger.py
+++ b/pete_e/cli/messenger.py
@@ -17,9 +17,10 @@ from typing_extensions import Annotated
 import typer
 import pathlib
 import psycopg
-import os
 import csv
 import json as jsonlib
+
+from pete_e.infrastructure.db_conn import get_database_url
 
 from pete_e.application.apple_dropbox_ingest import run_apple_health_ingest
 from pete_e.application.sync import run_sync_with_retries, run_withings_only_with_retries
@@ -773,9 +774,10 @@ def db(
     Run an ad-hoc SQL query. Supports {date} substitution,
     optional row limit, and CSV/JSON export.
     """
-    database_url = os.getenv("DATABASE_URL", settings.DATABASE_URL)
-    if not database_url:
-        console.print("[red]DATABASE_URL not configured in environment or settings.[/red]")
+    try:
+        database_url = get_database_url()
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1)
 
     # Handle {date} substitution
@@ -902,9 +904,10 @@ def metrics(
         console.print("[red]End date must be after or equal to start date.[/red]")
         raise typer.Exit(code=1)
 
-    database_url = os.getenv("DATABASE_URL", settings.DATABASE_URL)
-    if not database_url:
-        console.print("[red]DATABASE_URL not configured in environment or settings.[/red]")
+    try:
+        database_url = get_database_url()
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1)
 
     all_rows = []

--- a/pete_e/cli/status.py
+++ b/pete_e/cli/status.py
@@ -1,4 +1,4 @@
-﻿"""Health check command support for the pete CLI."""
+"""Health check command support for the pete CLI."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from typing import Callable, Iterable, List, Sequence
 
 import psycopg
 
-from pete_e.config.config import settings
+from pete_e.infrastructure.db_conn import get_database_url
 from pete_e.infrastructure.apple_dropbox_client import AppleDropboxClient
 from pete_e.infrastructure.withings_client import WithingsClient
 
@@ -41,7 +41,7 @@ def _format_exception(exc: Exception) -> str:
 def check_database(timeout: float = DEFAULT_TIMEOUT_SECONDS) -> CheckResult:
     start = perf_counter()
     try:
-        with psycopg.connect(settings.DATABASE_URL, connect_timeout=timeout) as conn:
+        with psycopg.connect(get_database_url(), connect_timeout=timeout) as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT 1")
                 cur.fetchone()
@@ -97,4 +97,3 @@ def render_results(results: Iterable[CheckResult]) -> str:
         status = "OK" if result.ok else "FAIL"
         lines.append(f"{result.name:<8} {status:<4} {result.detail}")
     return "\n".join(lines)
-

--- a/pete_e/infrastructure/database.py
+++ b/pete_e/infrastructure/database.py
@@ -4,9 +4,10 @@ from contextlib import contextmanager
 
 import psycopg
 
-from pete_e.config.config import settings
+from pete_e.infrastructure.db_conn import get_database_url
 
 # British English comments and docstrings.
+
 
 @contextmanager
 def get_conn():
@@ -15,5 +16,6 @@ def get_conn():
     For higher volume applications, this could be swapped for a connection pool.
     """
     # Use autocommit=False to ensure that transactions are managed explicitly.
-    with psycopg.connect(settings.DATABASE_URL, autocommit=False) as conn:
+    db_url = get_database_url()
+    with psycopg.connect(db_url, autocommit=False) as conn:
         yield conn

--- a/pete_e/infrastructure/db_conn.py
+++ b/pete_e/infrastructure/db_conn.py
@@ -1,0 +1,31 @@
+"""Utility helpers for database connection configuration."""
+
+from __future__ import annotations
+
+import os
+
+
+def get_database_url() -> str:
+    """Return the configured PostgreSQL connection URL.
+
+    Preference is given to the ``DATABASE_URL`` environment variable so that
+    command invocations can override configuration at runtime. If it is not
+    present, the value constructed from the ``POSTGRES_*`` settings is used.
+    A descriptive error is raised if neither source provides a connection
+    string, keeping failure modes explicit.
+    """
+
+    env_url = os.getenv("DATABASE_URL")
+    if env_url:
+        return env_url
+
+    from pete_e.config.config import settings
+
+    settings_url = settings.DATABASE_URL
+    if settings_url:
+        return settings_url
+
+    raise RuntimeError(
+        "Database connection information is missing. Set the DATABASE_URL "
+        "environment variable or configure the POSTGRES_* variables."
+    )

--- a/pete_e/infrastructure/plan_rw.py
+++ b/pete_e/infrastructure/plan_rw.py
@@ -11,7 +11,6 @@
 #   DATABASE_URL = postgresql://user:pass@host:port/dbname
 #
 
-import os
 import json
 import hashlib
 from contextlib import contextmanager
@@ -19,18 +18,15 @@ from datetime import date, datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from psycopg import connect
+from pete_e.infrastructure.db_conn import get_database_url
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
 
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-
 @contextmanager
 def conn_cursor():
-    if not DATABASE_URL:
-        raise RuntimeError("DATABASE_URL is not set")
-    conn = connect(DATABASE_URL, row_factory=dict_row)
+    db_url = get_database_url()
+    conn = connect(db_url, row_factory=dict_row)
     try:
         with conn:
             with conn.cursor() as cur:

--- a/pete_e/infrastructure/postgres_dal.py
+++ b/pete_e/infrastructure/postgres_dal.py
@@ -24,6 +24,7 @@ from psycopg.types.json import Json
 from psycopg_pool import ConnectionPool
 
 from pete_e.config import settings
+from pete_e.infrastructure.db_conn import get_database_url
 from pete_e.infrastructure import log_utils
 from ..domain.data_access import DataAccessLayer
 
@@ -36,10 +37,7 @@ from ..domain.data_access import DataAccessLayer
 _pool: ConnectionPool | None = None
 
 def _create_pool() -> ConnectionPool:
-    db_url = settings.DATABASE_URL
-    print("DEBUG DB URL:", settings.DATABASE_URL, type(settings.DATABASE_URL))
-    if not db_url:
-        raise ValueError("DATABASE_URL is not set in the configuration. Cannot initialize connection pool.")
+    db_url = get_database_url()
     return ConnectionPool(
         conninfo=db_url,
         min_size=1,


### PR DESCRIPTION
## Summary
- add a shared get_database_url helper in pete_e.infrastructure.db_conn to centralise connection string resolution
- refactor infrastructure modules, the API, and CLI commands to obtain database URLs through the new helper

## Testing
- pytest *(fails: missing optional dependencies such as pydantic and rich in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9961777c4832faa24dee4128f914e