### PR TITLE
Fix recovery scaling and Withings test stubs

### DIFF
--- a/pete_e/application/wger_sync.py
+++ b/pete_e/application/wger_sync.py
@@ -42,7 +42,7 @@ def fetch_all_pages(url: str, params: Optional[Dict[str, Any]] = None) -> List[D
             else:
                 logging.warning("Unexpected API response format. Stopping pagination.")
                 break
-        except requests.RequestException as e:
+        except requests.exceptions.RequestException as e:
             logging.error(f"Failed to fetch data from {next_url}: {e}")
             raise IOError(f"API request failed for {next_url}") from e
             

--- a/pete_e/infrastructure/telegram_sender.py
+++ b/pete_e/infrastructure/telegram_sender.py
@@ -120,7 +120,7 @@ def send_message(message: str) -> bool:
         response.raise_for_status()
         log_utils.log_message("Successfully sent message to Telegram.", "INFO")
         return True
-    except requests.RequestException as exc:
+    except requests.exceptions.RequestException as exc:
         error_details = _scrub_sensitive(str(exc).strip() or exc.__class__.__name__)
         log_utils.log_message(
             f"Failed to send message to Telegram: {error_details}",
@@ -151,7 +151,7 @@ def get_updates(*, offset: int | None = None, limit: int = 10, timeout: int = 0)
             timeout=max(1, wait_timeout + 5),
         )
         response.raise_for_status()
-    except requests.RequestException as exc:
+    except requests.exceptions.RequestException as exc:
         error_details = _scrub_sensitive(str(exc).strip() or exc.__class__.__name__)
         log_utils.log_message(
             f"Failed to fetch Telegram updates: {error_details}",

--- a/pete_e/infrastructure/wger_client.py
+++ b/pete_e/infrastructure/wger_client.py
@@ -75,7 +75,7 @@ class WgerClient:
         try:
             response = requests.get(url, headers=self.headers, params=params, timeout=self.timeout)
             response.raise_for_status()
-        except requests.RequestException as exc:
+        except requests.exceptions.RequestException as exc:
             log_message(f"Failed to fetch Wger logs: {exc}", "ERROR")
             return []
 

--- a/pete_e/infrastructure/wger_exporter.py
+++ b/pete_e/infrastructure/wger_exporter.py
@@ -152,14 +152,14 @@ class WgerClient:
                     attempt += 1
                     continue
                 raise WgerError(f"{method} {path} failed with {r.status_code}", r)
-            except requests.RequestException as exc:
+            except requests.exceptions.RequestException as exc:
                 last_exc = exc
                 sleep_for = self.backoff_base * (2 ** attempt)
                 logger.warning(f"[wger.api] network error on {method} {path}: {exc!r}, retrying in {sleep_for:.2f}s...")
                 time.sleep(sleep_for)
                 attempt += 1
 
-        if isinstance(last_exc, requests.RequestException):
+        if isinstance(last_exc, requests.exceptions.RequestException):
             raise WgerError(f"{method} {path} failed after retries: {last_exc!r}")
         raise WgerError(f"{method} {path} failed after retries")
 

--- a/pete_e/infrastructure/withings_client.py
+++ b/pete_e/infrastructure/withings_client.py
@@ -176,7 +176,7 @@ class WithingsClient:
                     http_status=exc.response.status_code if exc.response else None,
                 )
             raise RuntimeError(f"Withings ping failed: {reason or exc}") from exc
-        except requests.RequestException as exc:
+        except requests.exceptions.RequestException as exc:
             log_message(f"Withings ping request failed: {exc}", "ERROR")
             raise RuntimeError(f"Withings ping request failed: {exc}") from exc
 
@@ -361,7 +361,7 @@ class WithingsClient:
                     params=params,
                     timeout=self._request_timeout,
                 )
-            except requests.RequestException as exc:
+            except requests.exceptions.RequestException as exc:
                 log_message(f"Withings measures request failed: {exc}", "ERROR")
                 raise
 

--- a/scripts/catalog_refresh.py
+++ b/scripts/catalog_refresh.py
@@ -32,7 +32,7 @@ def fetch_all(url: str, params: Optional[Dict[str, Any]] = None) -> List[Dict[st
                 next_url = None
             else:
                 break
-        except requests.RequestException as e:
+        except requests.exceptions.RequestException as e:
             print(f"[ERROR] Failed to fetch data from {next_url}: {e}", file=sys.stderr)
             sys.exit(1)
     return results

--- a/tests/test_failure_modes.py
+++ b/tests/test_failure_modes.py
@@ -105,7 +105,17 @@ def test_withings_client_retries_rate_limits(monkeypatch):
     def fake_sleep(seconds):  # pragma: no cover - behaviour asserted via recorded calls
         sleep_calls.append(seconds)
 
+    def fake_post(url, data, timeout):  # pragma: no cover - exercised during token refresh
+        return DummyResponse(
+            status_code=200,
+            payload={
+                "status": 0,
+                "body": {"access_token": "abc", "refresh_token": "def"},
+            },
+        )
+
     monkeypatch.setattr("pete_e.infrastructure.withings_client.requests.get", fake_get)
+    monkeypatch.setattr("pete_e.infrastructure.withings_client.requests.post", fake_post)
     monkeypatch.setattr(withings_module.time, "sleep", fake_sleep)
 
     start = datetime(2024, 1, 1, tzinfo=timezone.utc)

--- a/tests/test_withings_token_permissions.py
+++ b/tests/test_withings_token_permissions.py
@@ -32,7 +32,7 @@ def test_oauth_helper_sets_owner_only_permissions(tmp_path, monkeypatch):
         def json(self):
             return {"status": 0, "body": {"access_token": "abc", "refresh_token": "def"}}
 
-    monkeypatch.setattr(oauth_helper.requests_mock, "post", lambda *_, **__: DummyResponse())
+    monkeypatch.setattr(oauth_helper.requests, "post", lambda *_, **__: DummyResponse())
 
     tokens = oauth_helper.exchange_code_for_tokens("code")
 


### PR DESCRIPTION
## Summary
- prevent backoff recommendations when observed metrics exactly match baselines and combine adherence adjustments without compounding reductions
- extend the test harness with pydantic, requests, and rich stubs while patching Withings token refreshes to keep unit tests self-contained
- normalize HTTP error handling to use requests.exceptions.RequestException across clients and scripts

## Tests
- `python - <<'PY'
import pytest
import tests.conftest
import importlib
importlib.import_module('pete_e.infrastructure.log_utils')
pytest.main(['tests/test_failure_modes.py', 'tests/test_validation_adherence.py', 'tests/test_validation.py::test_backoff_none_when_within_thresholds', 'tests/test_withings_token_permissions.py'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68db8e38be3c832f9e40d3fff48b8478