### PR TITLE
Hold users on same training week when adherence is low

### DIFF
--- a/pete_e/application/orchestrator.py
+++ b/pete_e/application/orchestrator.py
@@ -576,6 +576,40 @@ class Orchestrator:
             candidate += timedelta(days=7)
         return candidate
 
+    @staticmethod
+    def _resolve_export_week_number(
+        *,
+        calculated_week_number: int,
+        validation_decision: ValidationDecision | None,
+    ) -> int:
+        """Determine whether the athlete should advance or repeat the prior week."""
+
+        if calculated_week_number <= 1 or validation_decision is None:
+            return calculated_week_number
+
+        metrics = getattr(validation_decision, "recommendation", None)
+        recommendation_metrics = getattr(metrics, "metrics", {}) if metrics is not None else {}
+        adherence_metrics = (
+            recommendation_metrics.get("adherence", {})
+            if isinstance(recommendation_metrics, dict)
+            else {}
+        )
+        if not isinstance(adherence_metrics, dict):
+            return calculated_week_number
+        if not adherence_metrics.get("available"):
+            return calculated_week_number
+
+        try:
+            adherence_ratio = float(adherence_metrics.get("ratio", 1.0))
+        except (TypeError, ValueError):
+            adherence_ratio = 1.0
+
+        minimum_completion_ratio = 0.70
+        if adherence_ratio >= minimum_completion_ratio:
+            return calculated_week_number
+
+        return max(1, calculated_week_number - 1)
+
     def _export_active_week(
         self,
         *,
@@ -609,22 +643,32 @@ class Orchestrator:
             )
             return
 
+        exported_week_number = self._resolve_export_week_number(
+            calculated_week_number=week_number,
+            validation_decision=validation_decision,
+        )
+        if exported_week_number != week_number:
+            log_utils.info(
+                f"Holding progression for plan {plan_id}: adherence below completion threshold; "
+                f"re-exporting week {exported_week_number} into {week_start.isoformat()}."
+            )
+
         plan_weeks = self._coerce_positive_int(active_plan.get("weeks"))
-        if plan_weeks is not None and week_number > plan_weeks:
+        if plan_weeks is not None and exported_week_number > plan_weeks:
             log_utils.warn(
-                f"Skipping weekly export for plan {plan_id}: week {week_number} exceeds plan length {plan_weeks}",
+                f"Skipping weekly export for plan {plan_id}: week {exported_week_number} exceeds plan length {plan_weeks}",
                 "WARN",
             )
             return
 
         log_utils.info(
-            f"Exporting plan {plan_id} week {week_number} to wger for week starting {week_start.isoformat()}."
+            f"Exporting plan {plan_id} week {exported_week_number} to wger for week starting {week_start.isoformat()}."
         )
 
         try:
             self.export_service.export_plan_week(
                 plan_id=plan_id,
-                week_number=week_number,
+                week_number=exported_week_number,
                 start_date=week_start,
                 force_overwrite=True,
                 validation_decision=validation_decision,
@@ -633,13 +677,13 @@ class Orchestrator:
             raise
         except Exception as exc:  # pragma: no cover - defensive guard
             message = (
-                f"Weekly export failed for plan {plan_id} week {week_number} starting {week_start.isoformat()}: {exc}"
+                f"Weekly export failed for plan {plan_id} week {exported_week_number} starting {week_start.isoformat()}: {exc}"
             )
             log_utils.error(message, "ERROR")
             raise PlanRolloverError(message) from exc
         else:
             log_utils.info(
-                f"Exported plan {plan_id} week {week_number} to wger for {week_start.isoformat()}."
+                f"Exported plan {plan_id} week {exported_week_number} to wger for {week_start.isoformat()}."
             )
 
     @staticmethod

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -126,6 +126,45 @@ def test_run_end_to_end_week_exports_when_rollover_skipped(monkeypatch: pytest.M
     assert export_calls == [(13, 2, date(2024, 4, 29), None)]
 
 
+def test_run_end_to_end_week_repeats_prior_week_when_adherence_is_low(monkeypatch: pytest.MonkeyPatch):
+    export_calls: list[tuple[int, int, date, object]] = []
+    export_service = SimpleNamespace(
+        export_plan_week=lambda plan_id, week_number, start_date, force_overwrite=True, validation_decision=None: export_calls.append(
+            (plan_id, week_number, start_date, validation_decision)
+        )
+    )
+    dal = StubDal(active_plan={"id": 13, "start_date": date(2024, 4, 22), "weeks": 4})
+    container = build_stub_container(
+        dal=dal,
+        wger_client=SimpleNamespace(),
+        plan_service=SimpleNamespace(create_next_plan_for_cycle=lambda start_date: 99),
+        export_service=export_service,
+    )
+    orch = Orchestrator(container=container)
+
+    low_adherence_validation = SimpleNamespace(
+        recommendation=SimpleNamespace(
+            metrics={
+                "adherence": {
+                    "available": True,
+                    "ratio": 0.0,
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_weekly_calibration",
+        lambda self, reference_date: SimpleNamespace(message="ok", validation=low_adherence_validation),
+        raising=False,
+    )
+
+    result = orch.run_end_to_end_week(reference_date=date(2024, 4, 28))
+
+    assert result.rollover_triggered is False
+    assert export_calls == [(13, 1, date(2024, 4, 29), low_adherence_validation)]
+
+
 def test_run_end_to_end_day_sends_summary(monkeypatch: pytest.MonkeyPatch):
     sent_messages: list[str] = []
 


### PR DESCRIPTION
### Motivation
- Prevent automatic progression when a user has not completed enough of the prior week, so the same week is re-scheduled until sufficient adherence is recorded.

### Description
- Added `_resolve_export_week_number` to `Orchestrator` to decide whether to advance or repeat a week based on `ValidationDecision` adherence metrics and a minimum completion ratio of `0.70`.
- Updated `_export_active_week` to use the resolved `exported_week_number` for logging and to call `export_service.export_plan_week` with the held-back week when adherence is low.
- The hold-back logic is a no-op for week 1, when no `validation_decision` is provided, or when adherence metrics are unavailable.
- Added regression test `test_run_end_to_end_week_repeats_prior_week_when_adherence_is_low` in `tests/test_orchestrator.py` asserting that a low adherence `ratio` causes re-export of the prior week.

### Testing
- Ran `pytest -q tests/test_orchestrator.py tests/test_cycle_rollover.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e70d6814ac832fa3ce72f9fbfc30f0)