### PR TITLE
Add running prescriptions and treadmill workout details to plan generation and rendering

### DIFF
--- a/init-db/schema.sql
+++ b/init-db/schema.sql
@@ -324,7 +324,11 @@ CREATE TABLE training_plan_workouts (
     target_weight_kg NUMERIC(6,2),
     rir_cue NUMERIC(3,1),
     scheduled_time TIME,
-    is_cardio BOOLEAN NOT NULL DEFAULT false
+    is_cardio BOOLEAN NOT NULL DEFAULT false,
+    comment TEXT,
+    optional BOOLEAN NOT NULL DEFAULT false,
+    recovery_focused BOOLEAN NOT NULL DEFAULT false,
+    details JSONB
 );
 
 CREATE TABLE assistance_pool (

--- a/migrations/20260421_add_running_prescriptions.sql
+++ b/migrations/20260421_add_running_prescriptions.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE training_plan_workouts
+    ADD COLUMN IF NOT EXISTS comment TEXT,
+    ADD COLUMN IF NOT EXISTS optional BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS recovery_focused BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS details JSONB;
+
+COMMIT;

--- a/pete_e/domain/entities.py
+++ b/pete_e/domain/entities.py
@@ -132,6 +132,10 @@ class Workout:
     percent_1rm: float | None = None
     exercise: Exercise | None = None
     intensity: str | None = None
+    comment: str | None = None
+    optional: bool = False
+    recovery_focused: bool = False
+    details: MutableMapping[str, object] | None = None
 
     def is_weights_session(self) -> bool:
         return not self.is_cardio and self.type == "weights"

--- a/pete_e/domain/narrative_builder.py
+++ b/pete_e/domain/narrative_builder.py
@@ -692,6 +692,72 @@ def _format_weekly_heading(week_number: int, week_start: date | None) -> str:
         end=week_end.isoformat(),
     )
 
+
+def _clean_float(value: Any) -> str:
+    number = _to_float(value)
+    if number is None:
+        return str(value)
+    return f"{number:.1f}"
+
+
+def _render_treadmill_instruction(details: Mapping[str, Any]) -> str | None:
+    session_type = str(details.get("session_type") or "").strip().lower()
+    steps = details.get("steps")
+    if not isinstance(steps, list) or not steps:
+        return None
+
+    if session_type == "intervals":
+        warmup = steps[0] if len(steps) > 0 and isinstance(steps[0], Mapping) else {}
+        repeat = steps[1] if len(steps) > 1 and isinstance(steps[1], Mapping) else {}
+        cooldown = steps[2] if len(steps) > 2 and isinstance(steps[2], Mapping) else {}
+        repeat_steps = repeat.get("steps") if isinstance(repeat, Mapping) else None
+        work = repeat_steps[0] if isinstance(repeat_steps, list) and repeat_steps else {}
+        recovery = repeat_steps[1] if isinstance(repeat_steps, list) and len(repeat_steps) > 1 else {}
+        return (
+            f"Warmup {_clean_number(warmup.get('duration_minutes'))} min @ {_clean_float(warmup.get('speed_kph'))} km/h; "
+            f"{_clean_number(repeat.get('repeats'))} × "
+            f"({_clean_number(work.get('duration_minutes'))} min @ {_clean_float(work.get('speed_kph'))} km/h, "
+            f"{_clean_number(recovery.get('duration_minutes'))} min @ {_clean_float(recovery.get('speed_kph'))} km/h); "
+            f"Cooldown {_clean_number(cooldown.get('duration_minutes'))} min @ {_clean_float(cooldown.get('speed_kph'))} km/h"
+        )
+
+    step = steps[0] if isinstance(steps[0], Mapping) else {}
+    speed = _clean_float(step.get("speed_kph"))
+    min_speed = step.get("min_speed_kph")
+    max_speed = step.get("max_speed_kph")
+    speed_range = None
+    if min_speed is not None and max_speed is not None:
+        speed_range = f"{_clean_float(min_speed)}–{_clean_float(max_speed)}"
+
+    if session_type == "tempo":
+        warmup = steps[0] if len(steps) > 0 and isinstance(steps[0], Mapping) else {}
+        main = steps[1] if len(steps) > 1 and isinstance(steps[1], Mapping) else {}
+        cooldown = steps[2] if len(steps) > 2 and isinstance(steps[2], Mapping) else {}
+        return (
+            f"Warmup {_clean_number(warmup.get('duration_minutes'))} min @ {_clean_float(warmup.get('speed_kph'))} km/h; "
+            f"{_clean_number(main.get('duration_minutes'))} min @ {_clean_float(main.get('speed_kph'))} km/h; "
+            f"Cooldown {_clean_number(cooldown.get('duration_minutes'))} min @ {_clean_float(cooldown.get('speed_kph'))} km/h"
+        )
+    if session_type == "easy":
+        duration = _clean_number(step.get("duration_minutes"))
+        suffix = f" (easy range {speed_range})" if speed_range else ""
+        return f"{duration} min @ {speed} km/h{suffix}"
+    if session_type == "steady":
+        duration = _clean_number(step.get("duration_minutes"))
+        suffix = f" (steady range {speed_range})" if speed_range else ""
+        return f"{duration} min @ {speed} km/h{suffix}"
+    if session_type == "recovery":
+        min_duration = step.get("min_duration_minutes")
+        max_duration = step.get("max_duration_minutes")
+        if min_duration is not None and max_duration is not None:
+            return f"{_clean_number(min_duration)}–{_clean_number(max_duration)} min @ {speed} km/h"
+        return f"{_clean_number(step.get('duration_minutes'))} min @ {speed} km/h"
+    if session_type == "long_run":
+        distance = _clean_number(step.get("distance_km"))
+        suffix = f" (range {speed_range})" if speed_range else ""
+        return f"Long run: {distance} km @ {speed} km/h{suffix}"
+    return None
+
 def _format_weekly_workouts(plan_week_data: List[Dict[str, Any]]) -> tuple[List[str], List[str]]:
     workouts_by_day: Dict[int, List[str]] = {day: [] for day in range(1, 8)}
     for entry in plan_week_data:
@@ -702,18 +768,28 @@ def _format_weekly_workouts(plan_week_data: List[Dict[str, Any]]) -> tuple[List[
             continue
         if day_number not in workouts_by_day:
             continue
-        exercise = entry.get("exercise_name") or f"Exercise {entry.get('exercise_id')}"
+        details_payload = entry.get("details")
+        if isinstance(details_payload, Mapping):
+            exercise = str(entry.get("comment") or entry.get("exercise_name") or "Run")
+        else:
+            exercise = entry.get("exercise_name") or f"Exercise {entry.get('exercise_id')}"
         details: List[str] = []
+        if isinstance(details_payload, Mapping):
+            treadmill_line = _render_treadmill_instruction(details_payload)
+            if treadmill_line:
+                details.append(treadmill_line)
         sets = entry.get("sets")
         reps = entry.get("reps")
-        if sets is not None and reps is not None:
+        if sets is not None and reps is not None and not details:
             details.append(f"{_clean_number(sets)} x {_clean_number(reps)}")
         weight = entry.get("target_weight_kg") or entry.get("weight_kg")
-        if weight is not None:
+        if weight is not None and not details_payload:
             details.append(f"{_clean_number(weight)} kg")
         rir = entry.get("rir")
-        if rir is not None:
+        if rir is not None and not details_payload:
             details.append(f"RIR {_clean_number(rir)}")
+        if entry.get("optional"):
+            details.append("optional")
         detail_text = f" ({' · '.join(details)})" if details else ""
         workouts_by_day[day_number].append(f"{exercise}{detail_text}")
     bullet_lines: List[str] = []

--- a/pete_e/domain/plan_factory.py
+++ b/pete_e/domain/plan_factory.py
@@ -123,6 +123,77 @@ class PlanFactory:
                         "scheduled_time": slot_str,
                     })
 
+            # 5. Layer treadmill running around the fixed lifting split
+            quality_details = (
+                schedule_rules.quality_intervals_details()
+                if week_num % 2 == 1
+                else schedule_rules.quality_tempo_details()
+            )
+            week_workouts.append(
+                {
+                    "day_of_week": 1,
+                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                    "sets": 1,
+                    "reps": 1,
+                    "is_cardio": True,
+                    "comment": "Quality run",
+                    "details": quality_details,
+                }
+            )
+
+            week_workouts.append(
+                {
+                    "day_of_week": 2,
+                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                    "sets": 1,
+                    "reps": 1,
+                    "is_cardio": True,
+                    "comment": "Easy run",
+                    "details": schedule_rules.easy_run_details(),
+                    "optional": True,
+                    "recovery_focused": True,
+                }
+            )
+
+            week_workouts.append(
+                {
+                    "day_of_week": 4,
+                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                    "sets": 1,
+                    "reps": 1,
+                    "is_cardio": True,
+                    "comment": "Steady run",
+                    "details": schedule_rules.steady_run_details(),
+                }
+            )
+
+            week_workouts.append(
+                {
+                    "day_of_week": 5,
+                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                    "sets": 1,
+                    "reps": 1,
+                    "is_cardio": True,
+                    "comment": "Recovery micro run",
+                    "details": schedule_rules.recovery_micro_run_details(),
+                    "optional": True,
+                    "recovery_focused": True,
+                }
+            )
+
+            long_run_distance = 6 + (week_num - 1)
+            week_workouts.append(
+                {
+                    "day_of_week": 6,
+                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                    "sets": 1,
+                    "reps": 1,
+                    "is_cardio": True,
+                    "comment": "Long run",
+                    "details": schedule_rules.long_run_details(distance_km=long_run_distance),
+                }
+            )
+
             plan_weeks.append({"week_number": week_num, "workouts": week_workouts})
 
         return {"start_date": start_date, "weeks": weeks_in_plan, "plan_weeks": plan_weeks}

--- a/pete_e/domain/schedule_rules.py
+++ b/pete_e/domain/schedule_rules.py
@@ -10,7 +10,7 @@ in lockstep with the published template.
 from __future__ import annotations
 
 from datetime import time
-from typing import Dict, List
+from typing import Any, Dict, List
 
 # ------------------------------------------------------------------------------
 # Exercise identifiers
@@ -33,6 +33,11 @@ MAIN_LIFT_IDS: tuple[int, ...] = tuple(LIFT_CODE_BY_ID.keys())
 
 # Blaze is a fixed HIIT class logged as this id
 BLAZE_ID = 1630
+
+# Running exercise IDs from the seeded wger catalogue.
+TREADMILL_RUN_ID = 530
+OUTDOOR_RUN_ID = 527
+RUN_CARDIO_EXERCISE_ID = TREADMILL_RUN_ID
 
 # Blaze class start times by weekday (1=Mon ... 7=Sun)
 BLAZE_TIMES = {
@@ -253,7 +258,7 @@ def default_assistance_for(main_lift_id: int) -> List[int]:
 def classify_exercise(exercise_id: int | None) -> str:
     if exercise_id is None:
         return "other"
-    if exercise_id == BLAZE_ID:
+    if exercise_id in {BLAZE_ID, TREADMILL_RUN_ID, OUTDOOR_RUN_ID}:
         return "cardio"
     if exercise_id in MAIN_LIFT_IDS:
         return "main"
@@ -285,3 +290,108 @@ TEST_WEEK_PCTS = {
     OHP_ID: 85.0,
     DEADLIFT_ID: 90.0,
 }
+
+# ------------------------------------------------------------------------------
+# Treadmill running prescriptions
+# ------------------------------------------------------------------------------
+TREADMILL_DEFAULT_INCLINE_PERCENT = 0.0
+TREADMILL_OPTIONAL_INCLINE_HINT = "Optional: use 1% incline to mimic outdoor feel."
+ANCHOR_5K_PACE_KPH = 10.0
+
+
+def _base_running_details(session_type: str) -> Dict[str, Any]:
+    return {
+        "session_type": session_type,
+        "treadmill": True,
+        "incline_percent": TREADMILL_DEFAULT_INCLINE_PERCENT,
+        "anchor_pace_kph": ANCHOR_5K_PACE_KPH,
+        "incline_hint": TREADMILL_OPTIONAL_INCLINE_HINT,
+    }
+
+
+def quality_intervals_details() -> Dict[str, Any]:
+    details = _base_running_details("intervals")
+    details["steps"] = [
+        {"kind": "warmup", "duration_minutes": 5, "speed_kph": 8.5},
+        {
+            "kind": "repeat",
+            "repeats": 5,
+            "steps": [
+                {"kind": "work", "duration_minutes": 3, "speed_kph": 11.5},
+                {"kind": "recovery", "duration_minutes": 2, "speed_kph": 8.5},
+            ],
+        },
+        {"kind": "cooldown", "duration_minutes": 5, "speed_kph": 8.5},
+    ]
+    return details
+
+
+def quality_tempo_details() -> Dict[str, Any]:
+    details = _base_running_details("tempo")
+    details["steps"] = [
+        {"kind": "warmup", "duration_minutes": 5, "speed_kph": 8.5},
+        {"kind": "steady", "duration_minutes": 20, "speed_kph": 10.5},
+        {"kind": "cooldown", "duration_minutes": 5, "speed_kph": 8.5},
+    ]
+    return details
+
+
+def easy_run_details(*, duration_minutes: int = 20) -> Dict[str, Any]:
+    details = _base_running_details("easy")
+    details["steps"] = [
+        {
+            "kind": "steady",
+            "duration_minutes": duration_minutes,
+            "speed_kph": 8.9,
+            "min_speed_kph": 8.8,
+            "max_speed_kph": 9.0,
+        }
+    ]
+    return details
+
+
+def steady_run_details(*, duration_minutes: int = 35) -> Dict[str, Any]:
+    details = _base_running_details("steady")
+    details["steps"] = [
+        {
+            "kind": "steady",
+            "duration_minutes": duration_minutes,
+            "speed_kph": 9.9,
+            "min_speed_kph": 9.8,
+            "max_speed_kph": 10.0,
+        }
+    ]
+    return details
+
+
+def recovery_micro_run_details(*, duration_minutes: int = 12) -> Dict[str, Any]:
+    details = _base_running_details("recovery")
+    details["steps"] = [
+        {
+            "kind": "steady",
+            "duration_minutes": duration_minutes,
+            "min_duration_minutes": 10,
+            "max_duration_minutes": 15,
+            "speed_kph": 8.5,
+        }
+    ]
+    return details
+
+
+def long_run_details(*, distance_km: int) -> Dict[str, Any]:
+    details = _base_running_details("long_run")
+    details["steps"] = [
+        {
+            "kind": "long_run",
+            "distance_km": distance_km,
+            "speed_kph": 9.0,
+            "min_speed_kph": 8.8,
+            "max_speed_kph": 9.2,
+        }
+    ]
+    details["progression"] = {
+        "start_distance_km": 6,
+        "weekly_increment_km": 1,
+        "cap_distance_km": None,
+    }
+    return details

--- a/pete_e/infrastructure/mappers/plan_mapper.py
+++ b/pete_e/infrastructure/mappers/plan_mapper.py
@@ -130,6 +130,13 @@ class PlanMapper:
         workout_type = data.get("type") or ("cardio" if is_cardio else "weights")
         percent_1rm = converters.to_float(data.get("percent_1rm"))
         intensity = data.get("intensity")
+        comment = data.get("comment")
+        optional = bool(data.get("optional", False))
+        recovery_focused = bool(data.get("recovery_focused", False))
+        details_raw = data.get("details")
+        details: MutableMapping[str, Any] | None = None
+        if isinstance(details_raw, MutableMapping):
+            details = dict(details_raw)
 
         exercise = self._build_exercise(data)
 
@@ -142,6 +149,10 @@ class PlanMapper:
             percent_1rm=percent_1rm,
             exercise=exercise,
             intensity=intensity,
+            comment=None if comment is None else str(comment),
+            optional=optional,
+            recovery_focused=recovery_focused,
+            details=details,
         )
 
     def _build_exercise(self, data: Mapping[str, Any]) -> Exercise | None:
@@ -204,6 +215,10 @@ class PlanMapper:
             "type": workout.type,
             "percent_1rm": workout.percent_1rm,
             "intensity": workout.intensity,
+            "comment": workout.comment,
+            "optional": workout.optional,
+            "recovery_focused": workout.recovery_focused,
+            "details": None if workout.details is None else dict(workout.details),
         }
 
         if exercise is not None:

--- a/pete_e/infrastructure/postgres_dal.py
+++ b/pete_e/infrastructure/postgres_dal.py
@@ -177,6 +177,10 @@ class PostgresDal(PlanRepository):
             if scheduled_time is None:
                 scheduled_time = _coerce_scheduled_time(payload.get("slot"))
             is_cardio = bool(payload.get("is_cardio"))
+            comment = payload.get("comment")
+            optional = bool(payload.get("optional", False))
+            recovery_focused = bool(payload.get("recovery_focused", False))
+            details = payload.get("details")
 
             cur.execute(
                 """
@@ -191,9 +195,13 @@ class PostgresDal(PlanRepository):
                     target_weight_kg,
                     rir_cue,
                     scheduled_time,
-                    is_cardio
+                    is_cardio,
+                    comment,
+                    optional,
+                    recovery_focused,
+                    details
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     week_id,
@@ -207,6 +215,10 @@ class PostgresDal(PlanRepository):
                     rir_cue,
                     scheduled_time,
                     is_cardio,
+                    comment,
+                    optional,
+                    recovery_focused,
+                    Json(details) if details is not None else None,
                 ),
             )
 
@@ -299,7 +311,7 @@ class PostgresDal(PlanRepository):
                     raise
 
     def insert_workout(self, **kwargs) -> None:
-        sql = "INSERT INTO training_plan_workouts (week_id, day_of_week, exercise_id, sets, reps, rir, percent_1rm, target_weight_kg, scheduled_time, is_cardio) VALUES (%(week_id)s, %(day_of_week)s, %(exercise_id)s, %(sets)s, %(reps)s, %(rir_cue)s, %(percent_1rm)s, %(target_weight_kg)s, %(scheduled_time)s, %(is_cardio)s);"
+        sql = "INSERT INTO training_plan_workouts (week_id, day_of_week, exercise_id, sets, reps, rir, percent_1rm, target_weight_kg, scheduled_time, is_cardio, comment, optional, recovery_focused, details) VALUES (%(week_id)s, %(day_of_week)s, %(exercise_id)s, %(sets)s, %(reps)s, %(rir_cue)s, %(percent_1rm)s, %(target_weight_kg)s, %(scheduled_time)s, %(is_cardio)s, %(comment)s, %(optional)s, %(recovery_focused)s, %(details)s);"
         with self._get_cursor() as cur:
             cur.execute(sql, kwargs)
 

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -97,10 +97,11 @@ def test_plan_factory_builds_correct_block_structure(repo: DummyRepo):
         main_sets = len(schedule_rules.get_main_set_scheme(week_idx))
         for dow in schedule_rules.MAIN_LIFT_BY_DOW:
             expected_total += main_sets + 3 + int(dow in blaze_days)
+        expected_total += 5  # running sessions layered onto Mon/Tue/Thu/Fri/Sat
     assert len(all_workouts) == expected_total
 
     # Blaze cardio sessions should match the currently configured schedule.
-    blaze_workouts = [w for w in all_workouts if w["is_cardio"]]
+    blaze_workouts = [w for w in all_workouts if w["is_cardio"] and not w.get("details")]
     assert all(w["exercise_id"] == schedule_rules.BLAZE_ID for w in blaze_workouts)
     assert len(blaze_workouts) == len(blaze_days) * 4
 
@@ -145,3 +146,34 @@ def test_plan_factory_builds_correct_block_structure(repo: DummyRepo):
         summary = schedule_rules.main_set_summary(1)
         expected_weight = round((tm * summary["percent_1rm"] / 100) / 2.5) * 2.5
         assert heaviest["target_weight_kg"] == expected_weight
+
+    week1 = plan_dict["plan_weeks"][0]["workouts"]
+    week2 = plan_dict["plan_weeks"][1]["workouts"]
+
+    monday_week1 = [w for w in week1 if w["day_of_week"] == 1 and w.get("details")]
+    monday_week2 = [w for w in week2 if w["day_of_week"] == 1 and w.get("details")]
+    assert len(monday_week1) == 1
+    assert len(monday_week2) == 1
+    assert monday_week1[0]["exercise_id"] == schedule_rules.TREADMILL_RUN_ID
+    assert monday_week2[0]["exercise_id"] == schedule_rules.TREADMILL_RUN_ID
+    assert monday_week1[0]["details"]["session_type"] == "intervals"
+    assert monday_week2[0]["details"]["session_type"] == "tempo"
+
+    assert any(w["day_of_week"] == 2 and w.get("details", {}).get("session_type") == "easy" for w in week1)
+    assert any(w["day_of_week"] == 4 and w.get("details", {}).get("session_type") == "steady" for w in week1)
+    assert any(
+        w["day_of_week"] == 5
+        and w.get("details", {}).get("session_type") == "recovery"
+        and w.get("optional") is True
+        for w in week1
+    )
+    assert any(w["day_of_week"] == 6 and w.get("details", {}).get("session_type") == "long_run" for w in week1)
+
+    long_run_week1 = next(
+        w for w in week1 if w["day_of_week"] == 6 and w.get("details", {}).get("session_type") == "long_run"
+    )
+    long_run_week2 = next(
+        w for w in week2 if w["day_of_week"] == 6 and w.get("details", {}).get("session_type") == "long_run"
+    )
+    assert long_run_week1["details"]["steps"][0]["distance_km"] == 6
+    assert long_run_week2["details"]["steps"][0]["distance_km"] == 7

--- a/tests/test_strength_week_integration.py
+++ b/tests/test_strength_week_integration.py
@@ -28,7 +28,9 @@ def test_531_block_plan_includes_blaze_sessions(monkeypatch):
     plan = factory.create_531_block_plan(start_date=date(2024, 6, 3), training_maxes={})
 
     first_week = plan["plan_weeks"][0]
-    blaze_entries = [entry for entry in first_week["workouts"] if entry.get("is_cardio")]
+    blaze_entries = [
+        entry for entry in first_week["workouts"] if entry.get("is_cardio") and not entry.get("details")
+    ]
     expected_blaze_days = set(schedule_rules.BLAZE_TIMES).intersection(
         schedule_rules.MAIN_LIFT_BY_DOW
     )

--- a/tests/test_weekly_plan_message.py
+++ b/tests/test_weekly_plan_message.py
@@ -2,6 +2,8 @@
 
 from typer.testing import CliRunner
 
+import tests.config_stub  # noqa: F401
+
 from pete_e.cli import messenger
 from pete_e.domain import narrative_builder
 
@@ -113,3 +115,56 @@ def test_weekly_plan_cli_send_uses_formatted_overview(monkeypatch):
 
     assert result.exit_code == 0
     assert orch.sent_message == expected
+
+
+def test_weekly_plan_formats_interval_treadmill_steps():
+    rows = [
+        {
+            "day_of_week": 1,
+            "comment": "Quality run",
+            "details": {
+                "session_type": "intervals",
+                "steps": [
+                    {"kind": "warmup", "duration_minutes": 5, "speed_kph": 8.5},
+                    {
+                        "kind": "repeat",
+                        "repeats": 5,
+                        "steps": [
+                            {"kind": "work", "duration_minutes": 3, "speed_kph": 11.5},
+                            {"kind": "recovery", "duration_minutes": 2, "speed_kph": 8.5},
+                        ],
+                    },
+                    {"kind": "cooldown", "duration_minutes": 5, "speed_kph": 8.5},
+                ],
+            },
+        }
+    ]
+
+    message = narrative_builder.build_weekly_plan_summary(rows, week_number=1, week_start=real_date(2024, 9, 2))
+    assert "Warmup 5 min @ 8.5 km/h; 5 × (3 min @ 11.5 km/h, 2 min @ 8.5 km/h); Cooldown 5 min @ 8.5 km/h" in message
+
+
+def test_weekly_plan_formats_tempo_treadmill_steps():
+    rows = [
+        {
+            "day_of_week": 1,
+            "comment": "Quality run",
+            "details": {
+                "session_type": "tempo",
+                "steps": [
+                    {"kind": "warmup", "duration_minutes": 5, "speed_kph": 8.5},
+                    {"kind": "steady", "duration_minutes": 20, "speed_kph": 10.5},
+                    {"kind": "cooldown", "duration_minutes": 5, "speed_kph": 8.5},
+                ],
+            },
+        }
+    ]
+
+    message = narrative_builder.build_weekly_plan_summary(rows, week_number=1, week_start=real_date(2024, 9, 2))
+    assert "Warmup 5 min @ 8.5 km/h; 20 min @ 10.5 km/h; Cooldown 5 min @ 8.5 km/h" in message
+
+
+def test_weekly_plan_legacy_rows_render_without_treadmill_details():
+    rows = [{"day_of_week": 1, "exercise_name": "Bench Press", "sets": 5, "reps": 5, "rir": 2}]
+    message = narrative_builder.build_weekly_plan_summary(rows, week_number=1, week_start=real_date(2024, 9, 2))
+    assert "- Monday: Bench Press (5 x 5 · RIR 2)" in message


### PR DESCRIPTION
### Motivation

- Introduce structured running sessions (quality, easy, steady, recovery micro, long run) into the 5/3/1 block plans so cardio and run guidance can be generated and communicated alongside lifting work.
- Persist and surface textual comments and rich `details` for cardio workouts so treadmill-specific instructions can be rendered in weekly messages.

### Description

- Database schema: add `comment`, `optional`, `recovery_focused`, and `details JSONB` to `training_plan_workouts` and include a migration `migrations/20260421_add_running_prescriptions.sql` to apply the change, and update `init-db/schema.sql` accordingly.
- Domain & mapping: extend `Workout` to include `comment`, `optional`, `recovery_focused`, and `details`, and update `PlanMapper` and `plan_mapper` payload mapping to read/write these fields.
- Plan generation: update `PlanFactory` to layer multiple running sessions into each week (quality/tempo intervals, easy, steady, recovery micro, long run) using new helper functions in `schedule_rules` and mark optional/recovery flags where appropriate.
- Rendering and rules: add running constants and helper detail builders in `schedule_rules.py`, implement treadmill detail rendering and formatting helpers in `narrative_builder.py`, and update weekly formatting to prefer `comment` or `details` payloads for run display and mark optional sessions.
- Persistence: update `PostgresDal` SQL for inserting workouts to include the new columns and JSONB handling, and update DAL insert helpers to accept the new fields.
- Tests: add and adjust unit tests to assert running sessions are generated, persisted in `details`, and rendered correctly in weekly messages (`tests/test_plan_builder.py`, `tests/test_weekly_plan_message.py`, `tests/test_strength_week_integration.py`).

### Testing

- Ran the test suite with `pytest -q` against the modified modules and test files, and all tests passed.
- Added focused unit tests that validate plan composition including running sessions and treadmill detail rendering, and they succeeded when run locally.
- Existing plan generation and integration tests were updated to ignore treadmill `details` when asserting Blaze cardio entries and they pass under the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e714644510832f8ef138d5cdae9700)