### PR TITLE
Refactor running session planning into dedicated module

### DIFF
--- a/pete_e/domain/plan_factory.py
+++ b/pete_e/domain/plan_factory.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, List, Optional
 
 from pete_e.domain import schedule_rules
 from pete_e.domain.repositories import PlanRepository
+from pete_e.domain.running_planner import RunningPlanner
 
 class PlanFactory:
     """Creates structured, in-memory representations of training plans."""
@@ -21,6 +22,7 @@ class PlanFactory:
         and core exercise IDs.
         """
         self.plan_repository = plan_repository
+        self.running_planner = RunningPlanner()
 
     def _pick_random(self, items: List[Any], k: int) -> List[Any]:
         """Safely picks k random items from a list."""
@@ -136,75 +138,9 @@ class PlanFactory:
                         "scheduled_time": slot_str,
                     })
 
-            # 5. Layer treadmill running around the fixed lifting split
-            quality_details = (
-                schedule_rules.quality_intervals_details()
-                if week_num % 2 == 1
-                else schedule_rules.quality_tempo_details()
-            )
-            week_workouts.append(
-                {
-                    "day_of_week": 1,
-                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
-                    "sets": 1,
-                    "reps": 1,
-                    "is_cardio": True,
-                    "comment": "Quality run",
-                    "details": quality_details,
-                }
-            )
-
-            week_workouts.append(
-                {
-                    "day_of_week": 2,
-                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
-                    "sets": 1,
-                    "reps": 1,
-                    "is_cardio": True,
-                    "comment": "Easy run",
-                    "details": schedule_rules.easy_run_details(),
-                    "optional": True,
-                    "recovery_focused": True,
-                }
-            )
-
-            week_workouts.append(
-                {
-                    "day_of_week": 4,
-                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
-                    "sets": 1,
-                    "reps": 1,
-                    "is_cardio": True,
-                    "comment": "Steady run",
-                    "details": schedule_rules.steady_run_details(),
-                }
-            )
-
-            week_workouts.append(
-                {
-                    "day_of_week": 5,
-                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
-                    "sets": 1,
-                    "reps": 1,
-                    "is_cardio": True,
-                    "comment": "Recovery micro run",
-                    "details": schedule_rules.recovery_micro_run_details(),
-                    "optional": True,
-                    "recovery_focused": True,
-                }
-            )
-
-            long_run_distance = 6 + (week_num - 1)
-            week_workouts.append(
-                {
-                    "day_of_week": 6,
-                    "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
-                    "sets": 1,
-                    "reps": 1,
-                    "is_cardio": True,
-                    "comment": "Long run",
-                    "details": schedule_rules.long_run_details(distance_km=long_run_distance),
-                }
+            # 5. Layer running sessions around the fixed lifting split.
+            week_workouts.extend(
+                self.running_planner.build_week_sessions(week_number=week_num)
             )
 
             for dow in sorted(schedule_rules.TRAINING_DAY_STRETCH_ROUTINE_BY_DOW):

--- a/pete_e/domain/running_planner.py
+++ b/pete_e/domain/running_planner.py
@@ -1,0 +1,103 @@
+"""Running planning utilities.
+
+This module isolates running session construction from the strength plan builder
+so it can evolve toward adaptive, goal-driven planning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, List
+
+from pete_e.domain import schedule_rules
+
+
+@dataclass(frozen=True)
+class RunningGoal:
+    """Optional race goal inputs for future adaptive running logic."""
+
+    target_race: str | None = None
+    race_date: date | None = None
+    target_time: str | None = None
+
+
+class RunningPlanner:
+    """Builds running sessions for each training week."""
+
+    def build_week_sessions(
+        self,
+        *,
+        week_number: int,
+        goal: RunningGoal | None = None,
+        health_metrics: Dict[str, Any] | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Return running workouts for a given week.
+
+        ``goal`` and ``health_metrics`` are accepted now so the calling code can
+        pass richer context as the adaptive planning rules are expanded.
+        """
+
+        quality_details = (
+            schedule_rules.quality_intervals_details()
+            if week_number % 2 == 1
+            else schedule_rules.quality_tempo_details()
+        )
+
+        # TODO: incorporate goal/health-driven adjustments when readiness and
+        # completed session performance are threaded into plan generation.
+        _ = (goal, health_metrics)
+
+        long_run_distance = 6 + (week_number - 1)
+
+        return [
+            {
+                "day_of_week": 1,
+                "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                "sets": 1,
+                "reps": 1,
+                "is_cardio": True,
+                "comment": "Quality run",
+                "details": quality_details,
+            },
+            {
+                "day_of_week": 2,
+                "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                "sets": 1,
+                "reps": 1,
+                "is_cardio": True,
+                "comment": "Easy run",
+                "details": schedule_rules.easy_run_details(),
+                "optional": True,
+                "recovery_focused": True,
+            },
+            {
+                "day_of_week": 4,
+                "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                "sets": 1,
+                "reps": 1,
+                "is_cardio": True,
+                "comment": "Steady run",
+                "details": schedule_rules.steady_run_details(),
+            },
+            {
+                "day_of_week": 5,
+                "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                "sets": 1,
+                "reps": 1,
+                "is_cardio": True,
+                "comment": "Recovery micro run",
+                "details": schedule_rules.recovery_micro_run_details(),
+                "optional": True,
+                "recovery_focused": True,
+            },
+            {
+                "day_of_week": 6,
+                "exercise_id": schedule_rules.RUN_CARDIO_EXERCISE_ID,
+                "sets": 1,
+                "reps": 1,
+                "is_cardio": True,
+                "comment": "Long run",
+                "details": schedule_rules.long_run_details(distance_km=long_run_distance),
+            },
+        ]

--- a/tests/domain/test_running_planner.py
+++ b/tests/domain/test_running_planner.py
@@ -1,0 +1,23 @@
+from pete_e.domain import schedule_rules
+from pete_e.domain.running_planner import RunningPlanner
+
+
+def test_running_planner_builds_consistent_weekly_sessions() -> None:
+    planner = RunningPlanner()
+
+    week1 = planner.build_week_sessions(week_number=1)
+    week2 = planner.build_week_sessions(week_number=2)
+
+    assert len(week1) == 5
+    assert [session["day_of_week"] for session in week1] == [1, 2, 4, 5, 6]
+    assert all(session["exercise_id"] == schedule_rules.RUN_CARDIO_EXERCISE_ID for session in week1)
+
+    monday_week1 = next(session for session in week1 if session["day_of_week"] == 1)
+    monday_week2 = next(session for session in week2 if session["day_of_week"] == 1)
+    assert monday_week1["details"]["session_type"] == "intervals"
+    assert monday_week2["details"]["session_type"] == "tempo"
+
+    long_run_week1 = next(session for session in week1 if session["day_of_week"] == 6)
+    long_run_week2 = next(session for session in week2 if session["day_of_week"] == 6)
+    assert long_run_week1["details"]["steps"][0]["distance_km"] == 6
+    assert long_run_week2["details"]["steps"][0]["distance_km"] == 7


### PR DESCRIPTION
### Motivation
- Decouple running session construction from the strength plan builder to make running logic easier to extend toward goal-driven and health-adaptive planning.
- Provide explicit extension points so race goals and health metrics can be wired into running prescriptions without changing the core `PlanFactory` logic.

### Description
- Added a new module `pete_e/domain/running_planner.py` that introduces `RunningPlanner` and a `RunningGoal` dataclass and implements `build_week_sessions` to produce running workouts for a week.
- Updated `pete_e/domain/plan_factory.py` to import and instantiate `RunningPlanner` and replace the inlined running-building block with a call to `self.running_planner.build_week_sessions(week_number=week_num)`.
- Added unit tests in `tests/domain/test_running_planner.py` to validate weekly session structure, alternating quality session types, and progressive long-run distances.
- Kept existing plan generation behavior intact while creating a clear seam for future adaptive logic.

### Testing
- Ran `pytest -q tests/domain/test_running_planner.py tests/test_plan_builder.py` and both tests passed (`2 passed`).
- New tests exercise `RunningPlanner.build_week_sessions` and the existing `PlanFactory` behavior used by the `test_plan_builder` suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb37d0e164832f8245b31333d81c23)