### PR TITLE
Refactor shared metrics response-shaping helpers

### DIFF
--- a/pete_e/application/api_services.py
+++ b/pete_e/application/api_services.py
@@ -71,6 +71,60 @@ _LOW_TRUST_FIELDS = {
     "vo2_max",
 }
 
+_MODERATE_TRUST_FIELDS = {"steps", "stand_minutes", "flights_climbed", "time_in_daylight"}
+
+
+def _coerce_numeric(value: Any) -> float | int | None:
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return value
+    return converters.to_float(value)
+    """Perform coerce numeric."""
+
+
+def _metric_trust_level(metric_key: str) -> str:
+    if metric_key in _LOW_TRUST_FIELDS:
+        return "low"
+    if metric_key in _MODERATE_TRUST_FIELDS:
+        return "moderate"
+    return "high"
+    """Perform metric trust level."""
+
+
+def _metric_source(metric_key: str) -> str:
+    if metric_key in {"weight_kg", "body_fat_pct", "muscle_pct", "water_pct", "body_age_years"}:
+        return "withings_or_body_age"
+    if metric_key == "strength_volume_kg":
+        return "wger_logs"
+    return "apple_health"
+    """Perform metric source."""
+
+
+def _window_payload(*, end_date: date, days: int) -> dict[str, Any]:
+    return {
+        "start_date": (end_date - timedelta(days=days - 1)).isoformat(),
+        "end_date": end_date.isoformat(),
+        "days": days,
+    }
+    """Perform window payload."""
+
+
+def _shape_metric_entry(metric_key: str, raw_value: Any) -> dict[str, Any]:
+    value = _json_safe(_coerce_numeric(raw_value))
+    return {
+        "value": value,
+        "unit": _METRIC_UNITS.get(metric_key),
+        "source": _metric_source(metric_key),
+        "trust_level": _metric_trust_level(metric_key),
+        "is_imputed": False,
+        "data_quality": "missing" if value is None else "observed",
+    }
+    """Perform shape metric entry."""
+
+
 
 def _json_safe(value: Any) -> Any:
     if isinstance(value, Decimal):
@@ -160,20 +214,10 @@ class MetricsService(_DateParserMixin):
         for key, raw_value in row.items():
             if key == "date":
                 continue
-            value = _json_safe(raw_value)
-            if key in _PRIMARY_FIELDS and value is None:
+            metric_entry = _shape_metric_entry(key, raw_value)
+            if key in _PRIMARY_FIELDS and metric_entry["value"] is None:
                 missing.append(key)
-            trust_level = "low" if key in _LOW_TRUST_FIELDS else "high"
-            if key in {"steps", "stand_minutes", "flights_climbed", "time_in_daylight"}:
-                trust_level = "moderate"
-            metrics[key] = {
-                "value": value,
-                "unit": _METRIC_UNITS.get(key),
-                "source": self._source_for_metric(key),
-                "trust_level": trust_level,
-                "is_imputed": False,
-                "data_quality": "missing" if value is None else "observed",
-            }
+            metrics[key] = metric_entry
 
         completeness = self._completeness_pct([row], _PRIMARY_FIELDS)
         return {
@@ -195,11 +239,7 @@ class MetricsService(_DateParserMixin):
         running = running_fn(days=resolved_days, end_date=end_date) if callable(running_fn) else []
         strength = strength_fn(days=resolved_days, end_date=end_date) if callable(strength_fn) else []
         return {
-            "window": {
-                "start_date": (end_date - timedelta(days=resolved_days - 1)).isoformat(),
-                "end_date": end_date.isoformat(),
-                "days": resolved_days,
-            },
+            "window": _window_payload(end_date=end_date, days=resolved_days),
             "running": _json_safe(running),
             "strength": _json_safe(strength),
             "data_quality": {
@@ -364,11 +404,7 @@ class MetricsService(_DateParserMixin):
 
     @staticmethod
     def _source_for_metric(key: str) -> str:
-        if key in {"weight_kg", "body_fat_pct", "muscle_pct", "water_pct", "body_age_years"}:
-            return "withings_or_body_age"
-        if key == "strength_volume_kg":
-            return "wger_logs"
-        return "apple_health"
+        return _metric_source(key)
         """Perform source for metric."""
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- Consolidate duplicated response-shaping logic for metrics to ensure consistent numeric coercion, JSON safety, windowing, and metric metadata across endpoints.
- Make it easier to maintain trust/source rules and window payload construction in one place.
- Preserve existing endpoint payloads so external callers are unaffected by the refactor.

### Description
- Introduced `_MODERATE_TRUST_FIELDS` and reusable helpers: `_coerce_numeric`, `_metric_trust_level`, `_metric_source`, `_window_payload`, and `_shape_metric_entry` in `pete_e/application/api_services.py` to centralize shaping logic.
- Replaced inline metric shaping in `MetricsService.daily_summary` with ` _shape_metric_entry` while preserving response fields (`value`, `unit`, `source`, `trust_level`, `is_imputed`, `data_quality`) and primary-metric missing-field behavior.
- Replaced inline recent-workouts window construction in `MetricsService.recent_workouts` with `_window_payload` to standardize window formatting (`start_date`, `end_date`, `days`).
- Kept the public helper `MetricsService._source_for_metric` intact by delegating to the new `_metric_source` helper to maintain API compatibility.

### Testing
- `python -m py_compile pete_e/application/api_services.py` succeeded and the module compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc153c0770832f9ee32f25f40eac09)