### PR TITLE
Introduce PlanReadModel for plan snapshot normalization and context retrieval

### DIFF
--- a/pete_e/application/api_services.py
+++ b/pete_e/application/api_services.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 
 from pete_e.config import settings
 from pete_e.infrastructure.postgres_dal import PostgresDal
+from pete_e.application.plan_read_model import PlanReadModel
 from pete_e.utils import converters
 
 
@@ -527,19 +528,17 @@ class PlanService(_DateParserMixin):
     """Service for read-only access to stored plan snapshots."""
 
     def __init__(self, dal: PostgresDal):
-        self._dal = dal
+        self._read_model = PlanReadModel(dal)
         """Initialize this object."""
 
     def for_day(self, iso_date: str) -> Dict[str, Any]:
         target_date = self._parse_iso_date(iso_date, "date")
-        columns, rows = self._dal.get_plan_for_day(target_date)
-        return {"columns": columns, "rows": rows}
+        return self._read_model.plan_for_day(target_date)
         """Perform for day."""
 
     def for_week(self, iso_start_date: str) -> Dict[str, Any]:
         target_date = self._parse_iso_date(iso_start_date, "start_date")
-        columns, rows = self._dal.get_plan_for_week(target_date)
-        return {"columns": columns, "rows": rows}
+        return self._read_model.plan_for_week(target_date)
         """Perform for week."""
 
 

--- a/pete_e/application/orchestrator.py
+++ b/pete_e/application/orchestrator.py
@@ -27,6 +27,7 @@ from pete_e.application.collaborator_contracts import (
     ValidationContract,
 )
 from pete_e.application.plan_generation import PlanGenerationService  # 🆕 added
+from pete_e.application.plan_read_model import PlanReadModel
 from pete_e.application.services import PlanService, WgerExportService
 from pete_e.application.validation_service import ValidationService
 from pete_e.application.workflows import (
@@ -453,39 +454,17 @@ class Orchestrator:
         return context
 
     def _load_plan_for_day(self, target: date) -> Iterable[Dict[str, Any]]:
-        """Fetch the active plan rows for the given day, normalising shape."""
+        """Fetch normalized plan context rows for the given day."""
 
         dal = getattr(self, "dal", None)
         if dal is None or not hasattr(dal, "get_plan_for_day"):
             return []
 
         try:
-            columns, rows = dal.get_plan_for_day(target)
+            return PlanReadModel(dal).load_day_context(target)
         except Exception as exc:  # pragma: no cover - defensive guard
             log_utils.warn(f"Failed to load plan for {target.isoformat()}: {exc}")
             return []
-
-        if not rows:
-            return []
-
-        column_index = {name: idx for idx, name in enumerate(columns or [])}
-        normalised: List[Dict[str, Any]] = []
-        for row in rows:
-            if isinstance(row, dict):
-                normalised.append(dict(row))
-                continue
-            if not isinstance(row, Sequence) or isinstance(row, (str, bytes)):
-                continue
-            record: Dict[str, Any] = {}
-            for name, idx in column_index.items():
-                try:
-                    value = row[idx]
-                except (IndexError, TypeError):
-                    continue
-                record[name] = value
-            if record:
-                normalised.append(record)
-        return normalised
 
     def _summarise_session(self, plan_rows: Iterable[Dict[str, Any]]) -> str | None:
         """Generate a short descriptor for the day's planned training."""

--- a/pete_e/application/plan_read_model.py
+++ b/pete_e/application/plan_read_model.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+
+@dataclass
+class PlanReadModel:
+    """Read-model responsible for plan snapshot retrieval and row normalization."""
+
+    dal: Any
+
+    def plan_for_day(self, target_date: date) -> Dict[str, Any]:
+        columns, rows = self.dal.get_plan_for_day(target_date)
+        return {"columns": list(columns or []), "rows": self._normalise_rows(columns, rows)}
+
+    def plan_for_week(self, start_date: date) -> Dict[str, Any]:
+        columns, rows = self.dal.get_plan_for_week(start_date)
+        return {"columns": list(columns or []), "rows": self._normalise_rows(columns, rows)}
+
+    def load_day_context(self, target_date: date) -> List[Dict[str, Any]]:
+        """Load normalized daily plan rows suitable for trainer/context consumers."""
+
+        snapshot = self.plan_for_day(target_date)
+        return list(snapshot.get("rows") or [])
+
+    @staticmethod
+    def _normalise_rows(
+        columns: Sequence[str] | None,
+        rows: Iterable[Sequence[Any] | Dict[str, Any]] | None,
+    ) -> List[Dict[str, Any]]:
+        if not rows:
+            return []
+
+        column_index = {name: idx for idx, name in enumerate(columns or [])}
+        normalised: List[Dict[str, Any]] = []
+        for row in rows:
+            if isinstance(row, dict):
+                normalised.append(dict(row))
+                continue
+            if not isinstance(row, Sequence) or isinstance(row, (str, bytes)):
+                continue
+
+            record: Dict[str, Any] = {}
+            for name, idx in column_index.items():
+                try:
+                    record[name] = row[idx]
+                except (IndexError, TypeError):
+                    continue
+            if record:
+                normalised.append(record)
+        return normalised

--- a/tests/application/test_plan_read_model.py
+++ b/tests/application/test_plan_read_model.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pete_e.application.plan_read_model import PlanReadModel
+
+
+class StubDal:
+    def get_plan_for_day(self, target_date: date):
+        return ["exercise_name", "sets"], [["Squat", 5], {"exercise_name": "Run", "sets": None}]
+
+    def get_plan_for_week(self, start_date: date):
+        return ["day", "exercise_name"], [["Mon", "Bench"]]
+
+
+def test_plan_for_day_normalizes_rows_to_records() -> None:
+    payload = PlanReadModel(StubDal()).plan_for_day(date(2024, 2, 2))
+
+    assert payload["columns"] == ["exercise_name", "sets"]
+    assert payload["rows"] == [
+        {"exercise_name": "Squat", "sets": 5},
+        {"exercise_name": "Run", "sets": None},
+    ]
+
+
+def test_plan_for_week_normalizes_sequence_rows() -> None:
+    payload = PlanReadModel(StubDal()).plan_for_week(date(2024, 2, 5))
+
+    assert payload["rows"] == [{"day": "Mon", "exercise_name": "Bench"}]
+
+
+def test_load_day_context_returns_normalized_rows() -> None:
+    rows = PlanReadModel(StubDal()).load_day_context(date(2024, 2, 2))
+
+    assert rows[0]["exercise_name"] == "Squat"


### PR DESCRIPTION
### Motivation
- Centralize plan snapshot query/result shaping and avoid duplicating normalization in multiple consumers by introducing a dedicated read-model layer.
- Provide a single place to load day/week plan snapshots and a context-friendly day loader for orchestrator/trainer use (`plan_for_day`, `plan_for_week`, `load_day_context`).

### Description
- Added `pete_e/application/plan_read_model.py` implementing `PlanReadModel` with `plan_for_day`, `plan_for_week`, `load_day_context`, and a `_normalise_rows` helper to convert sequence rows into dict records.
- Updated API-facing `PlanService` (`pete_e/application/api_services.py`) to delegate `for_day` and `for_week` to `PlanReadModel` so endpoint contracts remain `columns`+`rows` while normalization is centralized.
- Replaced inline normalization in the orchestrator (`pete_e/application/orchestrator.py`) with `PlanReadModel(dal).load_day_context(...)` in `_load_plan_for_day` to reuse the read-model for context consumers.
- Added focused unit tests in `tests/application/test_plan_read_model.py` that validate normalization and context loading behavior.

### Testing
- Ran `pytest -q tests/application/test_plan_read_model.py tests/api/test_api_services.py tests/application/test_orchestrator_messages.py` and all tests passed (`16 passed`).
- New unit tests for `PlanReadModel` cover day/week normalization and `load_day_context` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc16829970832fb920a2e839b9b0f0)