### PR TITLE
Extract shared date/numeric coercion helpers into common utility

### DIFF
--- a/pete_e/application/api_services.py
+++ b/pete_e/application/api_services.py
@@ -10,6 +10,7 @@ from pete_e.config import settings
 from pete_e.infrastructure.postgres_dal import PostgresDal
 from pete_e.application.plan_read_model import PlanReadModel
 from pete_e.utils import converters
+from pete_e.utils.coercion import coerce_numeric
 
 
 _METRIC_UNITS = {
@@ -75,17 +76,6 @@ _LOW_TRUST_FIELDS = {
 _MODERATE_TRUST_FIELDS = {"steps", "stand_minutes", "flights_climbed", "time_in_daylight"}
 
 
-def _coerce_numeric(value: Any) -> float | int | None:
-    if isinstance(value, bool) or value is None:
-        return value
-    if isinstance(value, Decimal):
-        return float(value)
-    if isinstance(value, (int, float)):
-        return value
-    return converters.to_float(value)
-    """Perform coerce numeric."""
-
-
 def _metric_trust_level(metric_key: str) -> str:
     if metric_key in _LOW_TRUST_FIELDS:
         return "low"
@@ -114,7 +104,7 @@ def _window_payload(*, end_date: date, days: int) -> dict[str, Any]:
 
 
 def _shape_metric_entry(metric_key: str, raw_value: Any) -> dict[str, Any]:
-    value = _json_safe(_coerce_numeric(raw_value))
+    value = _json_safe(coerce_numeric(raw_value))
     return {
         "value": value,
         "unit": _METRIC_UNITS.get(metric_key),

--- a/pete_e/application/orchestrator.py
+++ b/pete_e/application/orchestrator.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from contextlib import nullcontext
 from datetime import date, datetime, timedelta
 from dataclasses import dataclass
-from decimal import Decimal
 from typing import Any, Dict, Iterable, List, Sequence
 
 # --- NEW Clean Imports ---
@@ -50,6 +49,7 @@ from pete_e.infrastructure.di_container import Container, get_container
 from pete_e.infrastructure.postgres_dal import PostgresDal
 from pete_e.infrastructure.telegram_client import TelegramClient
 from pete_e.infrastructure.wger_client import WgerClient
+from pete_e.utils.coercion import coerce_decimal_to_float
 
 
 @dataclass(frozen=True)
@@ -60,19 +60,12 @@ class WeeklyAutomationResult:
     """Represent WeeklyAutomationResult."""
 
 
-def _coerce_metric_value(value: Any) -> Any:
-    if isinstance(value, Decimal):
-        return float(value)
-    return value
-    """Perform coerce metric value."""
-
-
 def _build_metrics_overview_payload(
     *, columns: Sequence[str], rows: Iterable[Sequence[Any]], reference_date: date
 ) -> Dict[str, Any]:
     metrics: Dict[str, Dict[str, Any]] = {}
     for raw_row in rows or []:
-        entry = {str(column): _coerce_metric_value(raw_row[idx]) for idx, column in enumerate(columns)}
+        entry = {str(column): coerce_decimal_to_float(raw_row[idx]) for idx, column in enumerate(columns)}
         metric_name = entry.get("metric_name")
         if not metric_name:
             continue

--- a/pete_e/application/strength_test.py
+++ b/pete_e/application/strength_test.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Mapping
 from pete_e.domain import schedule_rules
 from pete_e.infrastructure import log_utils
 from pete_e.infrastructure.postgres_dal import PostgresDal
+from pete_e.utils.coercion import coerce_date, coerce_float, coerce_int
 
 AMRAP_EPLEY_SOURCE = "AMRAP_EPLEY"
 MAX_REASONABLE_AMRAP_REPS = 20
@@ -66,9 +67,9 @@ class StrengthTestService:
             log_utils.info("No strength test week found; leaving training maxes unchanged.")
             return None
 
-        plan_id = self._coerce_int(latest_test_week.get("plan_id"))
-        week_number = self._coerce_int(latest_test_week.get("week_number")) or 1
-        plan_start = self._coerce_date(latest_test_week.get("start_date"))
+        plan_id = coerce_int(latest_test_week.get("plan_id"))
+        week_number = coerce_int(latest_test_week.get("week_number")) or 1
+        plan_start = coerce_date(latest_test_week.get("start_date"))
         if plan_id is None or plan_start is None:
             raise ValueError("Latest strength test week is missing plan metadata.")
 
@@ -135,8 +136,8 @@ class StrengthTestService:
     ) -> dict[int, date]:
         planned: dict[int, date] = {}
         for row in rows:
-            exercise_id = self._coerce_int(row.get("exercise_id"))
-            day_of_week = self._coerce_int(row.get("day_of_week"))
+            exercise_id = coerce_int(row.get("exercise_id"))
+            day_of_week = coerce_int(row.get("day_of_week"))
             if exercise_id not in schedule_rules.TEST_WEEK_LIFT_ORDER or day_of_week is None:
                 continue
             planned[exercise_id] = week_start + timedelta(days=day_of_week - 1)
@@ -169,9 +170,9 @@ class StrengthTestService:
         """Perform best logged set."""
 
     def _row_to_logged_set(self, row: Mapping[str, Any]) -> _LoggedSet | None:
-        test_date = self._coerce_date(row.get("date"))
-        reps = self._coerce_int(row.get("reps"))
-        weight_kg = self._coerce_float(row.get("weight_kg"))
+        test_date = coerce_date(row.get("date"))
+        reps = coerce_int(row.get("reps"))
+        weight_kg = coerce_float(row.get("weight_kg"))
         if test_date is None or reps is None or weight_kg is None:
             return None
         if reps < 1 or reps > MAX_REASONABLE_AMRAP_REPS or weight_kg <= 0:
@@ -194,42 +195,3 @@ class StrengthTestService:
         return weight_kg * (1.0 + reps / 30.0)
         """Perform e1rm epley."""
 
-    @staticmethod
-    def _coerce_date(value: Any) -> date | None:
-        if value is None:
-            return None
-        if isinstance(value, datetime):
-            return value.date()
-        if isinstance(value, date):
-            return value
-        if isinstance(value, str):
-            try:
-                return date.fromisoformat(value)
-            except ValueError:
-                return None
-        return None
-        """Perform coerce date."""
-
-    @staticmethod
-    def _coerce_int(value: Any) -> int | None:
-        if value is None:
-            return None
-        if isinstance(value, bool):
-            return int(value)
-        if isinstance(value, int):
-            return value
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-        """Perform coerce int."""
-
-    @staticmethod
-    def _coerce_float(value: Any) -> float | None:
-        if value is None:
-            return None
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return None
-        """Perform coerce float."""

--- a/pete_e/utils/coercion.py
+++ b/pete_e/utils/coercion.py
@@ -1,0 +1,73 @@
+"""Shared coercion helpers for date/time and numeric values."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+
+def coerce_decimal_to_float(value: Any) -> Any:
+    """Convert ``Decimal`` to ``float`` while preserving other values."""
+
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def coerce_numeric(value: Any) -> float | int | None:
+    """Coerce common numeric values while preserving ``bool`` and ``None``."""
+
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return value
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def coerce_date(value: Any) -> date | None:
+    """Best-effort conversion to ``date`` from supported date-like values."""
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def coerce_int(value: Any) -> int | None:
+    """Best-effort conversion to ``int`` compatible with existing strength-test rules."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def coerce_float(value: Any) -> float | None:
+    """Best-effort conversion to ``float``."""
+
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None


### PR DESCRIPTION
### Motivation
- Remove duplicated date/time and numeric coercion logic present in multiple application modules to centralize behavior and reduce maintenance burden.
- Preserve existing edge-case handling (e.g., `bool`/`None` semantics, `Decimal` conversion and ISO date parsing) while making the helpers reusable.

### Description
- Add `pete_e/utils/coercion.py` implementing `coerce_decimal_to_float`, `coerce_numeric`, `coerce_date`, `coerce_int`, and `coerce_float` as shared helpers.
- Update `pete_e/application/api_services.py` to use `coerce_numeric` when shaping metric entries, replacing the local numeric coercion implementation.
- Update `pete_e/application/orchestrator.py` to use `coerce_decimal_to_float` when building the metrics overview payload, replacing the local decimal-to-float helper.
- Update `pete_e/application/strength_test.py` to use `coerce_date`, `coerce_int`, and `coerce_float` for parsing plan metadata and logged sets, removing the duplicate static coercion methods.

### Testing
- Ran the targeted test subset with `pytest -q tests/api/test_api_services.py tests/test_strength_test.py tests/test_orchestrator.py` and all tests passed.
- Test run result: `17 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc18999044832fa8df0c43ef4b96ed)