### PR TITLE
Refactor dependency composition into explicit providers + test DI fixtures

### DIFF
--- a/pete_e/application/composition.py
+++ b/pete_e/application/composition.py
@@ -1,0 +1,74 @@
+"""Application dependency composition roots and provider helpers."""
+from __future__ import annotations
+
+from typing import Callable
+
+from pete_e.application.services import PlanService, WgerExportService
+from pete_e.application.validation_service import ValidationService
+from pete_e.domain.cycle_service import CycleService
+from pete_e.domain.daily_sync import AppleHealthIngestor, DailySyncService
+from pete_e.domain.narrative_builder import NarrativeBuilder
+from pete_e.infrastructure.apple_dropbox_client import AppleDropboxClient
+from pete_e.infrastructure.apple_health_ingestor import AppleHealthDropboxIngestor
+from pete_e.infrastructure.postgres_dal import PostgresDal
+from pete_e.infrastructure.telegram_client import TelegramClient
+from pete_e.infrastructure.token_storage import JsonFileTokenStorage
+from pete_e.infrastructure.wger_client import WgerClient
+from pete_e.infrastructure.withings_client import WithingsClient
+
+
+def provide_postgres_dal() -> PostgresDal:
+    return PostgresDal()
+
+
+def provide_wger_client() -> WgerClient:
+    return WgerClient()
+
+
+def provide_apple_dropbox_client() -> AppleDropboxClient:
+    return AppleDropboxClient()
+
+
+def provide_withings_client() -> WithingsClient:
+    return WithingsClient(token_storage=JsonFileTokenStorage(WithingsClient.TOKEN_FILE))
+
+
+def provide_telegram_client() -> TelegramClient:
+    return TelegramClient()
+
+
+def provide_apple_health_ingestor(*, dal: PostgresDal, client: AppleDropboxClient) -> AppleHealthIngestor:
+    return AppleHealthDropboxIngestor(dal=dal, client=client)
+
+
+def provide_plan_service(*, dal: PostgresDal) -> PlanService:
+    return PlanService(dal)
+
+
+def provide_wger_export_service(*, dal: PostgresDal, wger_client: WgerClient) -> WgerExportService:
+    return WgerExportService(dal=dal, wger_client=wger_client)
+
+
+def provide_daily_sync_service(
+    *, repository: PostgresDal, withings_source: WithingsClient, apple_ingestor: AppleHealthIngestor
+) -> DailySyncService:
+    return DailySyncService(
+        repository=repository,
+        withings_source=withings_source,
+        apple_ingestor=apple_ingestor,
+    )
+
+
+def provide_validation_service(*, dal: PostgresDal) -> ValidationService:
+    return ValidationService(dal)
+
+
+def provide_cycle_service() -> CycleService:
+    return CycleService()
+
+
+def provide_narrative_builder() -> NarrativeBuilder:
+    return NarrativeBuilder()
+
+
+OrchestratorFactory = Callable[..., object]

--- a/pete_e/application/orchestrator.py
+++ b/pete_e/application/orchestrator.py
@@ -16,6 +16,11 @@ from pete_e.application.exceptions import (
     PlanRolloverError,
     ValidationError,
 )
+from pete_e.application.composition import (
+    provide_cycle_service,
+    provide_narrative_builder,
+    provide_validation_service,
+)
 from pete_e.application.collaborator_contracts import (
     CycleContract,
     DataAccessContract,
@@ -103,8 +108,8 @@ class Orchestrator:
         self.plan_service = plan_service or container.resolve(PlanService)
         self.export_service = export_service or container.resolve(WgerExportService)
         self.daily_sync_service = daily_sync_service or container.resolve(DailySyncService)
-        self.validation_service = validation_service or ValidationService(self.dal)
-        self.cycle_service = cycle_service or CycleService()
+        self.validation_service = validation_service or self._resolve_validation_service(container)
+        self.cycle_service = cycle_service or self._resolve_cycle_service(container)
 
         try:
             self.telegram_client = telegram_client or container.resolve(TelegramClient)
@@ -115,7 +120,7 @@ class Orchestrator:
                     "TelegramClient dependency is unavailable; Telegram sends will be disabled."
                 )
 
-        self.narrative_builder = narrative_builder or NarrativeBuilder()
+        self.narrative_builder = narrative_builder or provide_narrative_builder()
 
         self.weekly_calibration_workflow = WeeklyCalibrationWorkflow(self.validation_service)
         self.cycle_rollover_workflow = CycleRolloverWorkflow(
@@ -142,6 +147,19 @@ class Orchestrator:
         except Exception as exc:  # defensive guard
             self.plan_generation_service = None
             log_utils.error(f"Failed to initialize PlanGenerationService: {exc}")
+
+
+    def _resolve_validation_service(self, container: Container) -> ValidationContract:
+        try:
+            return container.resolve(ValidationService)
+        except KeyError:
+            return provide_validation_service(dal=self.dal)
+
+    def _resolve_cycle_service(self, container: Container) -> CycleContract:
+        try:
+            return container.resolve(CycleService)
+        except KeyError:
+            return provide_cycle_service()
 
     def _hold_plan_generation_lock(self):
         holder = getattr(self.dal, "hold_plan_generation_lock", None)

--- a/pete_e/infrastructure/di_container.py
+++ b/pete_e/infrastructure/di_container.py
@@ -6,16 +6,29 @@ from functools import lru_cache
 import inspect
 from typing import Any, Callable, Dict, Type
 
+from pete_e.application.composition import (
+    provide_apple_dropbox_client,
+    provide_apple_health_ingestor,
+    provide_cycle_service,
+    provide_daily_sync_service,
+    provide_plan_service,
+    provide_postgres_dal,
+    provide_telegram_client,
+    provide_validation_service,
+    provide_wger_client,
+    provide_wger_export_service,
+    provide_withings_client,
+)
 from pete_e.application.services import PlanService, WgerExportService
+from pete_e.application.validation_service import ValidationService
 from pete_e.config import settings as app_settings
 from pete_e.domain.configuration import DomainSettings, configure as configure_domain
+from pete_e.domain.cycle_service import CycleService
 from pete_e.domain.daily_sync import AppleHealthIngestor, DailySyncService
 from pete_e.infrastructure.apple_dropbox_client import AppleDropboxClient
-from pete_e.infrastructure.apple_health_ingestor import AppleHealthDropboxIngestor
 from pete_e.infrastructure.postgres_dal import PostgresDal
 from pete_e.infrastructure.telegram_client import TelegramClient
 from pete_e.infrastructure.wger_client import WgerClient
-from pete_e.infrastructure.token_storage import JsonFileTokenStorage
 from pete_e.infrastructure.withings_client import WithingsClient
 
 configure_domain(
@@ -75,37 +88,36 @@ class Container:
 
 def _register_defaults(container: Container) -> None:
     """Register the production service graph with the container."""
-    container.register(PostgresDal, factory=lambda _c: PostgresDal())
-    container.register(WgerClient, factory=lambda _c: WgerClient())
-    container.register(AppleDropboxClient, factory=lambda _c: AppleDropboxClient())
-    container.register(
-        WithingsClient,
-        factory=lambda _c: WithingsClient(token_storage=JsonFileTokenStorage(WithingsClient.TOKEN_FILE)),
-    )
-    container.register(TelegramClient, factory=lambda _c: TelegramClient())
+    container.register(PostgresDal, factory=lambda _c: provide_postgres_dal())
+    container.register(WgerClient, factory=lambda _c: provide_wger_client())
+    container.register(AppleDropboxClient, factory=lambda _c: provide_apple_dropbox_client())
+    container.register(WithingsClient, factory=lambda _c: provide_withings_client())
+    container.register(TelegramClient, factory=lambda _c: provide_telegram_client())
     container.register(
         AppleHealthIngestor,
-        factory=lambda c: AppleHealthDropboxIngestor(
+        factory=lambda c: provide_apple_health_ingestor(
             dal=c.resolve(PostgresDal),
             client=c.resolve(AppleDropboxClient),
         ),
     )
-    container.register(PlanService, factory=lambda c: PlanService(c.resolve(PostgresDal)))
+    container.register(PlanService, factory=lambda c: provide_plan_service(dal=c.resolve(PostgresDal)))
     container.register(
         WgerExportService,
-        factory=lambda c: WgerExportService(
+        factory=lambda c: provide_wger_export_service(
             dal=c.resolve(PostgresDal),
             wger_client=c.resolve(WgerClient),
         ),
     )
     container.register(
         DailySyncService,
-        factory=lambda c: DailySyncService(
+        factory=lambda c: provide_daily_sync_service(
             repository=c.resolve(PostgresDal),
             withings_source=c.resolve(WithingsClient),
             apple_ingestor=c.resolve(AppleHealthIngestor),
         ),
     )
+    container.register(ValidationService, factory=lambda c: provide_validation_service(dal=c.resolve(PostgresDal)))
+    container.register(CycleService, factory=lambda _c: provide_cycle_service())
 
 
 def _wrap_override(provider: Any) -> Factory:

--- a/tests/di_utils.py
+++ b/tests/di_utils.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any, Dict, Mapping, Type
 
 from pete_e.application.services import PlanService, WgerExportService
+from pete_e.application.collaborator_contracts import CycleContract, ValidationContract
 from pete_e.domain.daily_sync import DailySyncResult, DailySyncService
+from pete_e.domain.cycle_service import CycleService
+from pete_e.application.validation_service import ValidationService
 from pete_e.infrastructure.di_container import build_container
 from pete_e.infrastructure.postgres_dal import PostgresDal
 from pete_e.infrastructure.wger_client import WgerClient
@@ -57,4 +60,23 @@ class _NoopDailySyncService:
     """Represent NoopDailySyncService."""
 
 
-__all__ = ["build_stub_container"]
+__all__ = ["build_stub_container", "build_contract_container"]
+
+
+def build_contract_container(
+    *,
+    dal: Any | None = None,
+    validation_service: ValidationContract | None = None,
+    cycle_service: CycleContract | None = None,
+    extra_overrides: Mapping[ServiceType, Any] | None = None,
+):
+    """Build a test container with contract-level overrides for fast unit tests."""
+    overrides: Dict[ServiceType, Any] = {
+        ValidationService: validation_service or ValidationService(dal or object()),
+        CycleService: cycle_service or CycleService(),
+    }
+    if dal is not None:
+        overrides[PostgresDal] = dal
+    if extra_overrides:
+        overrides.update(extra_overrides)
+    return build_container(overrides=overrides)

--- a/tests/test_composition_fixtures.py
+++ b/tests/test_composition_fixtures.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pete_e.application.collaborator_contracts import ValidationContract
+from pete_e.application.orchestrator import Orchestrator
+from tests.di_utils import _NoopDailySyncService
+from pete_e.infrastructure.postgres_dal import PostgresDal
+
+from tests.di_utils import build_contract_container
+
+
+@dataclass
+class _ValidationStub(ValidationContract):
+    calls: int = 0
+
+    def validate(self, reference_date):
+        self.calls += 1
+        return None
+
+
+class _DalStub:
+    def get_active_plan(self):
+        return None
+
+
+def test_contract_fixture_can_swap_validation_dependency():
+    validation = _ValidationStub()
+    container = build_contract_container(
+        dal=_DalStub(),
+        validation_service=validation,
+    )
+
+    orchestrator = Orchestrator(container=container, daily_sync_service=_NoopDailySyncService())
+
+    assert orchestrator.validation_service is validation
+    assert isinstance(container.resolve(PostgresDal), _DalStub)


### PR DESCRIPTION
### Motivation
- Centralize construction/wiring of application and infrastructure dependencies so the service graph is explicit and easier to reason about.
- Make it straightforward to swap contract implementations for fast unit tests without pulling full integration wiring into test suites.
- Reduce ad-hoc constructor calls throughout the codebase by exposing reusable provider functions for common collaborators.

### Description
- Added `pete_e/application/composition.py` containing explicit `provide_*` factory/provider functions for DAL, clients, sync services, validation, cycle and narrative builders.
- Updated `pete_e/infrastructure/di_container.py` to consume the composition providers for container registration and to register `ValidationService` and `CycleService` as overridable container entries.
- Updated `pete_e/application/orchestrator.py` to prefer container-resolved `ValidationService`/`CycleService` with a provider fallback and to use the new `provide_narrative_builder` helper.
- Added `build_contract_container` test helper in `tests/di_utils.py` and a focused unit test `tests/test_composition_fixtures.py` that demonstrates swapping a `ValidationContract` implementation via the container fixture.

### Testing
- Ran `pytest -q tests/test_composition_fixtures.py tests/test_orchestrator.py`; initial run surfaced a configuration-instantiation error which was addressed, and the final run completed with all tests passing.
- Final automated test run: `9 passed` (command used: `pytest -q tests/test_composition_fixtures.py tests/test_orchestrator.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1a76a484832f86bdbe61d65301f2)