### PR TITLE
Fix Prompt12 migration regressions: restore API compatibility, expand stretch exports, and resolve mypy duplicate discovery

### DIFF
--- a/pete_e/__init__.py
+++ b/pete_e/__init__.py
@@ -1,0 +1,1 @@
+"""Pete-Eebot package."""

--- a/pete_e/api.py
+++ b/pete_e/api.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Header, HTTPException, Query, Request
 
 from pete_e.api_routes import (
     logs_webhooks_router,
@@ -7,6 +7,11 @@ from pete_e.api_routes import (
     root_router,
     status_sync_router,
 )
+from pete_e.api_routes.dependencies import get_status_service, validate_api_key
+from pete_e.api_routes.logs_webhooks import logs
+from pete_e.application.sync import run_sync_with_retries
+from pete_e.cli.status import DEFAULT_TIMEOUT_SECONDS, render_results
+from pete_e.config import settings
 
 app = FastAPI(title="Pete-Eebot API")
 
@@ -15,3 +20,41 @@ app.include_router(metrics_router)
 app.include_router(plan_router)
 app.include_router(status_sync_router)
 app.include_router(logs_webhooks_router)
+
+
+def status(
+    request: Request,
+    x_api_key: str = Header(None),
+    timeout: float = Query(DEFAULT_TIMEOUT_SECONDS, ge=0.1),
+):
+    validate_api_key(request, x_api_key)
+    try:
+        results = get_status_service().run_checks(timeout=timeout)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    checks = [{"name": r.name, "ok": r.ok, "detail": r.detail} for r in results]
+    return {"ok": all(result["ok"] for result in checks), "checks": checks, "summary": render_results(results)}
+
+
+def sync(
+    request: Request,
+    x_api_key: str = Header(None),
+    days: int = Query(7, ge=1),
+    retries: int = Query(3, ge=0),
+):
+    validate_api_key(request, x_api_key)
+    try:
+        result = run_sync_with_retries(days=days, retries=retries)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    return {
+        "success": result.success,
+        "attempts": result.attempts,
+        "failed_sources": result.failed_sources,
+        "source_statuses": result.source_statuses,
+        "undelivered_alerts": result.undelivered_alerts,
+        "label": result.label,
+        "summary": result.summary_line(days=days),
+    }

--- a/pete_e/application/services.py
+++ b/pete_e/application/services.py
@@ -493,6 +493,8 @@ class WgerExportService:
             week_number,
             plan_id=plan_id,
         )
+        if bool(getattr(settings, "WGER_EXPAND_STRETCH_ROUTINES", False)):
+            self._expand_stretch_routines_for_export(payload)
         return payload
 
     def _annotate_week_payload(

--- a/tests/integration/test_api_contracts.py
+++ b/tests/integration/test_api_contracts.py
@@ -20,6 +20,9 @@ if "fastapi" not in sys.modules:
         return value
 
     class APIRouter:
+        def __init__(self, *args, **kwargs):
+            pass
+
         def get(self, *args, **kwargs):
             def decorator(func):
                 return func
@@ -31,6 +34,9 @@ if "fastapi" not in sys.modules:
                 return func
 
             return decorator
+
+        def include_router(self, *args, **kwargs):
+            return None
 
     fastapi_module.APIRouter = APIRouter
     fastapi_module.FastAPI = APIRouter


### PR DESCRIPTION
### Motivation
- Restore compatibility after the module reorganization so existing tests and callers that import symbols from `pete_e.api` continue to work. 
- Resolve the mypy duplicate-module discovery error caused by package path ambiguity after moving route modules. 
- Fix a regression where stretch routines were not expanded for Wger export when the expansion feature flag was enabled, causing export tests to fail.

### Description
- Added `pete_e/__init__.py` as a package marker to prevent duplicate-module discovery by type-checking tools. 
- Restored compatibility exports in `pete_e/api.py` by re-exporting `status`, `sync` and the API-compatible Request/HTTP exception wiring while keeping the composed `FastAPI` router bootstrap. 
- Applied optional stretch-routine expansion inside `WgerExportService._build_payload_from_rows` when `settings.WGER_EXPAND_STRETCH_ROUTINES` is truthy so exports are expanded before further processing. 
- Adjusted the FastAPI test-double in `tests/integration/test_api_contracts.py` to accept constructor kwargs and support `include_router(...)` calls to avoid import-time crashes in tests.

### Testing
- Ran `pytest -q` and all tests passed: `245 passed, 1 skipped`. 
- Ran `mypy pete_e tests` and the earlier duplicate-module error for `pete_e/api_routes/logs_webhooks.py` is resolved, but type-checking still reports missing third-party stubs (e.g., `fastapi`, `psycopg`, `typer`, `pydantic`, `requests`) in this environment. 
- Ran `ruff check .` and repository-wide lint debt remains (pre-existing issues) and was not addressed by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1fdff6dc832fb25a5cb2b83fcd57)