### PR TITLE
Expose `settings` in `pete_e.api` to fix failing tests

### DIFF
--- a/pete_e/api.py
+++ b/pete_e/api.py
@@ -9,6 +9,7 @@ from pete_e.api_routes import (
 )
 from pete_e.api_routes.dependencies import get_status_service, validate_api_key
 from pete_e.application.sync import run_sync_with_retries
+from pete_e.config import settings
 from pete_e.cli.status import DEFAULT_TIMEOUT_SECONDS, render_results
 
 app = FastAPI(title="Pete-Eebot API")


### PR DESCRIPTION
### Motivation
- Tests monkeypatch `api.settings` (e.g. to set `PETEEEBOT_API_KEY` and `log_path`) but `pete_e.api` did not expose a `settings` symbol, causing fixture setup to raise `AttributeError` and several endpoint tests to error.

### Description
- Import `settings` from `pete_e.config` into `pete_e/api.py` so `pete_e.api.settings` exists for tests that patch configuration values.

### Testing
- Observed automated test runs: the original CI `pytest -q` reported `241 passed, 1 skipped, 4 errors` with the errors caused by the missing `pete_e.api.settings`, and a local run of `pytest -q tests/test_api_cli_commands.py` after the change failed during collection because the test's `fastapi` stub lacks `FastAPI.include_router`, which is unrelated to the `settings` import fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc24ff4948832f848f9a2db513c310)