### PR TITLE
Expose api module `settings` without triggering Ruff unused-import

### DIFF
--- a/pete_e/api.py
+++ b/pete_e/api.py
@@ -9,8 +9,10 @@ from pete_e.api_routes import (
 )
 from pete_e.api_routes.dependencies import get_status_service, validate_api_key
 from pete_e.application.sync import run_sync_with_retries
-from pete_e.config import settings
+from pete_e.config import settings as _settings
 from pete_e.cli.status import DEFAULT_TIMEOUT_SECONDS, render_results
+
+settings = _settings  # Backward-compatible module export for tests/consumers.
 
 app = FastAPI(title="Pete-Eebot API")
 


### PR DESCRIPTION
### Motivation
- Keep `settings` available as `pete_e.api.settings` for tests and consumers that monkeypatch it while avoiding Ruff `F401` (unused-import) warnings.

### Description
- Import `settings` under an internal alias (`from pete_e.config import settings as _settings`) and re-export it with `settings = _settings` in `pete_e/api.py` to provide a backward-compatible module attribute without appearing unused to the linter.

### Testing
- `ruff check pete_e/api.py tests/test_api_cli_commands.py` — passed.
- `pytest -q tests/config/test_settings.py` — passed (3 tests).
- Targeted run of two tests from `tests/test_api_cli_commands.py` errored on import with `AttributeError` because that test file provides a local `fastapi` stub missing `include_router`, which is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc26b6dba0832fa20f2f9b1e8e8460)