### PR TITLE
Fix API module compatibility for tests (export logs, guard router registration)

### DIFF
--- a/pete_e/api.py
+++ b/pete_e/api.py
@@ -7,6 +7,7 @@ from pete_e.api_routes import (
     root_router,
     status_sync_router,
 )
+from pete_e.api_routes.logs_webhooks import github_webhook, logs
 from pete_e.api_routes.dependencies import get_status_service, validate_api_key
 from pete_e.application.sync import run_sync_with_retries
 from pete_e.config import settings as _settings
@@ -16,11 +17,12 @@ settings = _settings  # Backward-compatible module export for tests/consumers.
 
 app = FastAPI(title="Pete-Eebot API")
 
-app.include_router(root_router)
-app.include_router(metrics_router)
-app.include_router(plan_router)
-app.include_router(status_sync_router)
-app.include_router(logs_webhooks_router)
+if hasattr(app, "include_router"):
+    app.include_router(root_router)
+    app.include_router(metrics_router)
+    app.include_router(plan_router)
+    app.include_router(status_sync_router)
+    app.include_router(logs_webhooks_router)
 
 
 def status(


### PR DESCRIPTION
### Motivation
- Ensure the `pete_e.api` module remains importable and backwards-compatible for consumers/tests that call `api.logs(...)` and for the test FastAPI stub which lacks `include_router`.

### Description
- Re-export the `logs` and `github_webhook` callables into `pete_e.api` by importing them from `pete_e.api_routes.logs_webhooks` so `api.logs(...)` continues to work.
- Guard router registration behind `if hasattr(app, "include_router"):` so a minimal FastAPI stub used in tests can import `pete_e.api` without raising `AttributeError`.

### Testing
- Ran `pytest -q` and all tests passed with `245 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc28b291f0832f98488661816ce3c9)