### PR TITLE
Restore legacy `api.logs` export to fix endpoint contract test

### DIFF
--- a/pete_e/api.py
+++ b/pete_e/api.py
@@ -8,6 +8,7 @@ from pete_e.api_routes import (
     status_sync_router,
 )
 from pete_e.api_routes.dependencies import get_status_service, validate_api_key
+from pete_e.api_routes.logs_webhooks import github_webhook, logs
 from pete_e.application.sync import run_sync_with_retries
 from pete_e.config import settings as _settings
 from pete_e.cli.status import DEFAULT_TIMEOUT_SECONDS, render_results


### PR DESCRIPTION
### Motivation
- Restore module-level `logs` export so consumers and tests that call `pete_e.api.logs` do not raise `AttributeError` and to fix the CI failure in the logs endpoint contract test.

### Description
- Re-export `github_webhook` and `logs` by importing them from `pete_e.api_routes.logs_webhooks` in `pete_e/api.py` so the functions are available as `pete_e.api.logs` and `pete_e.api.github_webhook`.

### Testing
- Ran `pytest -q tests/test_api_cli_commands.py::test_logs_endpoint_returns_tail`, which passed. 
- Ran the full suite with `pytest -q`, which completed successfully with `245 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2f2bdf08832fad5b8607f92066d0)