### PR TITLE
Refine morning run guidance to ignore strength-only plans

### DIFF
--- a/pete_e/application/orchestrator.py
+++ b/pete_e/application/orchestrator.py
@@ -433,11 +433,7 @@ class Orchestrator:
             recent_runs = []
 
         plan_rows = list(self._load_plan_for_day(action_date))
-        planned_names = [
-            str(row.get("exercise_name"))
-            for row in plan_rows
-            if row.get("exercise_name")
-        ]
+        planned_names = self._extract_running_plan_names(plan_rows)
 
         adjustment = assess_morning_run_adjustment(
             health_metrics=historical_rows,
@@ -475,6 +471,39 @@ class Orchestrator:
         except Exception as exc:  # pragma: no cover - defensive guard
             log_utils.warn(f"Failed to load plan for {target.isoformat()}: {exc}")
             return []
+
+    @staticmethod
+    def _extract_running_plan_names(plan_rows: Iterable[Dict[str, Any]]) -> List[str]:
+        """Return unique plan exercise names that look like running sessions."""
+
+        run_tokens = (
+            "run",
+            "jog",
+            "interval",
+            "tempo",
+            "fartlek",
+            "sprint",
+            "hill",
+            "track",
+            "5k",
+            "10k",
+            "marathon",
+        )
+        names: List[str] = []
+        for row in plan_rows:
+            raw_name = row.get("exercise_name")
+            if not raw_name:
+                continue
+            label = str(raw_name).strip()
+            if not label:
+                continue
+            lowered = label.lower()
+            if not any(token in lowered for token in run_tokens):
+                continue
+            if label in names:
+                continue
+            names.append(label)
+        return names
 
     def _summarise_session(self, plan_rows: Iterable[Dict[str, Any]]) -> str | None:
         """Generate a short descriptor for the day's planned training."""

--- a/tests/application/test_orchestrator_messages.py
+++ b/tests/application/test_orchestrator_messages.py
@@ -168,6 +168,16 @@ def test_get_daily_summary_uses_builder():
     """Perform test get daily summary uses builder."""
 
 
+class _StrengthOnlyRunGuidanceDal(_RunGuidanceDal):
+    def get_plan_for_day(self, target_date: date):
+        return ["workout_date", "exercise_name"], [
+            (target_date, "TRX Rows"),
+            (target_date, "Deadlifts"),
+        ]
+        """Perform get plan for day."""
+    """Represent StrengthOnlyRunGuidanceDal."""
+
+
 def test_get_daily_summary_appends_running_backoff_guidance():
     action_date = date(2024, 6, 10)
     overview_rows = [{"metric_name": "weight", "yesterday_value": 82.0}]
@@ -182,6 +192,22 @@ def test_get_daily_summary_appends_running_backoff_guidance():
     assert "Run adjustment for Quality run" in result
     assert "swap today's run" in result
     """Perform test get daily summary appends running backoff guidance."""
+
+
+def test_get_daily_summary_does_not_label_strength_plan_as_run_adjustment():
+    action_date = date(2024, 6, 10)
+    overview_rows = [{"metric_name": "weight", "yesterday_value": 82.0}]
+    dal = _StrengthOnlyRunGuidanceDal(overview_rows, action_date=action_date)
+    builder = _NarrativeBuilder()
+
+    orch = _orchestrator_for(dal, narrative_builder=builder)
+
+    result = orch.get_daily_summary(target_date=action_date)
+
+    assert result.startswith("rendered-narrative")
+    assert "Run adjustment for" not in result
+    assert "Run adjustment:" in result
+    """Perform test get daily summary does not label strength plan as run adjustment."""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- The morning report sometimes labels strength-only days (e.g., `TRX Rows`, `Deadlifts`) as runs, producing confusing lines like “Run adjustment for TRX Rows”.
- The root cause was passing all planned exercise names into the run-backoff logic rather than only run-like sessions.
- The change scopes run guidance to genuinely running sessions so the narrative better matches plan intent.

### Description
- Update `_build_morning_run_guidance` to use a new helper and pass `planned_session_names` filtered for run-like items instead of all exercises. (`pete_e/application/orchestrator.py`)
- Add `@staticmethod _extract_running_plan_names` which token-matches and de-duplicates plan exercise names that look like running sessions (tokens include `run`, `jog`, `tempo`, `interval`, `5k`, `10k`, etc.). (`pete_e/application/orchestrator.py`)
- Add a regression test ensuring strength-only plans do not produce `Run adjustment for ...` phrasing by introducing `_StrengthOnlyRunGuidanceDal` and `test_get_daily_summary_does_not_label_strength_plan_as_run_adjustment`. (`tests/application/test_orchestrator_messages.py`)
- Keep existing behavior for genuine run sessions unchanged (the run-backoff logic in `assess_morning_run_adjustment` remains intact).

### Testing
- Ran `pytest -q tests/application/test_orchestrator_messages.py` and the suite passed: `6 passed`.
- The added regression test verifies that strength-only plans yield generic run guidance text without being labeled as a specific planned run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd703cab78832f8a661ded4a24e0de)