### PR TITLE
Simplify weekly plan output to concise day-by-day format

### DIFF
--- a/pete_e/domain/narrative_builder.py
+++ b/pete_e/domain/narrative_builder.py
@@ -1359,36 +1359,29 @@ def build_weekly_plan_summary(
     if not plan_week_data:
         return _no_plan_message(week_number)
 
-    bullets, rest_days = _format_weekly_workouts(plan_week_data)
-    rest_line = _format_rest_line(rest_days)
-    if rest_line:
-        bullets.append(rest_line)
+    workouts_by_day: Dict[int, List[str]] = {day: [] for day in range(1, 8)}
+    day_lines, _ = _format_weekly_workouts(plan_week_data)
+    for line in day_lines:
+        if not line.startswith("- ") or ": " not in line:
+            continue
+        day_label, entries_text = line[2:].split(": ", 1)
+        day_number = next((num for num, label in _DAY_NAMES.items() if label == day_label), None)
+        if day_number is None:
+            continue
+        workouts_by_day[day_number] = [chunk.strip() for chunk in entries_text.split("|") if chunk.strip()]
 
-    if not bullets:
-        bullets = ["- No scheduled sessions landed – let's map some training blocks."]
+    lines: List[str] = [f"Cycle week: {week_number}"]
+    for day_number in range(1, 8):
+        sessions = workouts_by_day.get(day_number, [])
+        if not sessions:
+            continue
+        lines.append(f"{_DAY_NAMES[day_number]}:")
+        lines.extend(session for session in sessions)
+        lines.append("")
 
-    closers = [f"Coach's call: Week {week_number} is all about momentum - lock it in."]
-    closers.extend(
-        _closing_phrases(
-            ["#Motivation"],
-            "Remember: consistency beats intensity every time.",
-            secondary_tags=["#Humour"],
-            secondary_fallback="Keep the banter high and the stress low.",
-        )
-    )
-
-    message = CoachMessage(
-        greeting=helpers.choose_from(
-            _COACH_WEEKLY_GREETINGS,
-            "Coach Pete here",
-            rand=random,
-        ),
-        heading=_format_weekly_heading(week_number, week_start),
-        bullets=bullets,
-        narrative=[],
-        closers=closers,
-    )
-    return message.render()
+    if lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
 
 
 # -------------------------------------------------------------------------

--- a/tests/test_weekly_plan_message.py
+++ b/tests/test_weekly_plan_message.py
@@ -99,12 +99,10 @@ def test_weekly_plan_cli_formats_overview(monkeypatch):
     assert result.exit_code == 0
     output = result.stdout.strip()
     assert expected in output
-    assert "Yo Ric! Coach Pete's weekly huddle incoming" in output
-    assert "*Week 1 Game Plan · 2024-09-02 → 2024-09-08*" in output
-    assert "- Monday: Squat (3 x 5 · RIR 2) | Bench Press (3 x 8 · RIR 1)" in output
-    assert "- Rest windows: Tuesday, Thursday, Friday, Saturday, Sunday - keep them mobile." in output
-    assert "Coach's call: Week 1 is all about momentum - lock it in." in output
-    assert "Remember to hydrate." in output
+    assert "Cycle week: 1" in output
+    assert "Monday:" in output
+    assert "Squat (3 x 5 · RIR 2)" in output
+    assert "Bench Press (3 x 8 · RIR 1)" in output
     assert orch.sent_message is None
 
 
@@ -168,7 +166,8 @@ def test_weekly_plan_formats_tempo_treadmill_steps():
 def test_weekly_plan_legacy_rows_render_without_treadmill_details():
     rows = [{"day_of_week": 1, "exercise_name": "Bench Press", "sets": 5, "reps": 5, "rir": 2}]
     message = narrative_builder.build_weekly_plan_summary(rows, week_number=1, week_start=real_date(2024, 9, 2))
-    assert "- Monday: Bench Press (5 x 5 · RIR 2)" in message
+    assert "Monday:" in message
+    assert "Bench Press (5 x 5 · RIR 2)" in message
 
 
 def test_weekly_plan_formats_limber_11_and_orders_run_weights_stretch():
@@ -213,8 +212,12 @@ def test_weekly_plan_formats_limber_11_and_orders_run_weights_stretch():
     ]
 
     message = narrative_builder.build_weekly_plan_summary(rows, week_number=1, week_start=real_date(2024, 9, 2))
-    monday_line = next(line for line in message.splitlines() if line.startswith("- Monday:"))
+    lines = message.splitlines()
+    monday_idx = lines.index("Monday:")
+    tuesday_idx = len(lines)
+    monday_entries = lines[monday_idx + 1:tuesday_idx]
 
-    assert monday_line.index("Quality run") < monday_line.index("Bench Press") < monday_line.index("Limber 11")
-    assert "Seated Piriformis Stretch [isometric]" in monday_line
-    assert "Rear-foot-elevated Hip Flexor Stretch [dynamic + 3s hold]" in monday_line
+    joined = "\n".join(monday_entries)
+    assert joined.index("Quality run") < joined.index("Bench Press") < joined.index("Limber 11")
+    assert "Seated Piriformis Stretch [isometric]" in joined
+    assert "Rear-foot-elevated Hip Flexor Stretch [dynamic + 3s hold]" in joined


### PR DESCRIPTION
### Motivation
- The weekly plan dump was too verbose and chatty for quick scanning and needed a concise, machine-friendly layout. 
- The goal was to produce a compact per-day plan that lists sessions plainly rather than a full coach-style narrative.

### Description
- Reworked `build_weekly_plan_summary` in `pete_e/domain/narrative_builder.py` to emit a compact format starting with `Cycle week: <n>` and day headers like `Monday:` followed by one line per session. 
- The new implementation reuses `_format_weekly_workouts` to preserve existing treadmill and stretch formatting and workout ordering, splitting the prior combined day line into individual session lines. 
- Removed the verbose weekly greeting/heading/closers and the old rest-window prose from the weekly-dump output. 
- Fixed a stray unterminated string literal and adjusted `tests/test_weekly_plan_message.py` assertions to validate the new compact structure and preserved treadmill/stretch details.

### Testing
- Ran `pytest -q tests/test_weekly_plan_message.py` and the suite completed successfully with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd77c27f2c832f9e1cdcd3f2353b09)