### PR TITLE
Phase 1: Add ContextAssembler and StressBudgetEngine and wire into UnifiedLoadCoordinator

### DIFF
--- a/pete_e/domain/data_access.py
+++ b/pete_e/domain/data_access.py
@@ -98,6 +98,33 @@ class DataAccessLayer(ABC):
         return []
         """Perform get recent strength workouts."""
 
+    def get_recent_strength_workload(
+        self,
+        *,
+        days: int = 14,
+        end_date: Optional[date] = None,
+    ) -> float:
+        workouts = self.get_recent_strength_workouts(days=days, end_date=end_date)
+        total = 0.0
+        for workout in workouts:
+            if isinstance(workout, dict):
+                total += float(workout.get("volume_kg", 0.0) or 0.0)
+        return total
+        """Perform get recent strength workload."""
+
+    def get_latest_training_maxes(self) -> Dict[str, Optional[float]]:
+        return {}
+        """Perform get latest training maxes."""
+
+    def get_recent_adherence_signal(
+        self,
+        *,
+        days: int = 21,
+        end_date: Optional[date] = None,
+    ) -> Optional[float]:
+        return None
+        """Perform get recent adherence signal."""
+
     @abstractmethod
     def get_data_for_validation(self, week_start: date) -> Dict[str, Any]:
         """Return all data required for validation for the supplied week."""
@@ -286,4 +313,3 @@ class DataAccessLayer(ABC):
     ) -> None:
         pass
         """Perform record wger export."""
-

--- a/pete_e/domain/unified_load_coordinator.py
+++ b/pete_e/domain/unified_load_coordinator.py
@@ -1,11 +1,11 @@
-"""Phase 0 unified planner domain primitives and coordinator skeleton."""
+"""Unified planner domain primitives + Phase 1 context/budget engines."""
 
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import date
 from enum import Enum
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from pete_e.domain import logging as log_utils
 
@@ -28,6 +28,10 @@ class WeeklyStressBudget:
     target: float
     minimum: float
     maximum: float
+    run_target: float = 0.0
+    strength_target: float = 0.0
+    confidence: float = 0.0
+    insufficient_data_flags: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -48,6 +52,105 @@ class GlobalTrainingContext:
     readiness_score: float
     historical_weekly_load: float
     constraints: SessionConstraintSet
+    goal_phase: str = "build"
+    training_maxes: Dict[str, Optional[float]] = field(default_factory=dict)
+    recent_running_workouts: tuple[Dict[str, Any], ...] = ()
+    historical_health_metrics: tuple[Dict[str, Any], ...] = ()
+    recent_strength_workload: float = 0.0
+    adherence_ratio: Optional[float] = None
+    insufficient_data_flags: tuple[str, ...] = ()
+
+
+class ContextAssembler:
+    """Collect all planning inputs from DAL-like collaborators."""
+
+    def __init__(self, dal: Any) -> None:
+        self._dal = dal
+
+    def assemble(self, *, plan_start_date: date, week_number: int, goal_phase: str = "build") -> GlobalTrainingContext:
+        flags: list[str] = []
+        training_maxes = self._safe_call("get_latest_training_maxes", default={})
+        running = self._safe_call("get_recent_running_workouts", default=[], kwargs={"days": 14, "end_date": plan_start_date})
+        health = self._safe_call("get_historical_metrics", default=[], args=(21,))
+        strength = self._safe_call("get_recent_strength_workouts", default=[], kwargs={"days": 14, "end_date": plan_start_date})
+        adherence = self._safe_call("get_recent_adherence_signal", default=None, kwargs={"days": 21, "end_date": plan_start_date})
+        readiness_score = self._derive_readiness_score(health)
+        historical_weekly_load = self._estimate_historical_weekly_load(running, strength)
+        strength_workload = self._estimate_strength_workload(strength)
+        if not training_maxes:
+            flags.append("missing_training_maxes")
+        if len(running) < 2:
+            flags.append("limited_running_history")
+        if len(health) < 7:
+            flags.append("limited_health_history")
+        if len(strength) < 2:
+            flags.append("limited_strength_history")
+        return GlobalTrainingContext(
+            plan_start_date=plan_start_date,
+            week_number=week_number,
+            readiness_score=readiness_score,
+            historical_weekly_load=historical_weekly_load,
+            constraints=SessionConstraintSet(max_sessions=5, min_recovery_days=1),
+            goal_phase=goal_phase,
+            training_maxes=training_maxes,
+            recent_running_workouts=tuple(running),
+            historical_health_metrics=tuple(health),
+            recent_strength_workload=strength_workload,
+            adherence_ratio=adherence,
+            insufficient_data_flags=tuple(flags),
+        )
+
+    def _safe_call(self, fn_name: str, *, default: Any, args: tuple[Any, ...] = (), kwargs: Optional[dict[str, Any]] = None) -> Any:
+        fn = getattr(self._dal, fn_name, None)
+        if not callable(fn):
+            return default
+        return fn(*args, **(kwargs or {}))
+
+    def _derive_readiness_score(self, history: List[Dict[str, Any]]) -> float:
+        if not history:
+            return 0.5
+        latest = history[-1] if isinstance(history[-1], dict) else {}
+        hrv = float(latest.get("hrv_recovery_score") or latest.get("hrv_score") or 50.0)
+        body = float(latest.get("body_battery") or latest.get("recovery_score") or 50.0)
+        return max(0.0, min(1.0, ((hrv + body) / 2.0) / 100.0))
+
+    def _estimate_historical_weekly_load(self, running: List[Dict[str, Any]], strength: List[Dict[str, Any]]) -> float:
+        run_points = sum(float(w.get("duration_sec", 0.0)) / 60.0 for w in running)
+        strength_points = sum(float(w.get("volume_kg", 0.0)) / 100.0 for w in strength)
+        return round((run_points + strength_points) / 2.0, 1)
+
+    def _estimate_strength_workload(self, strength: List[Dict[str, Any]]) -> float:
+        return round(sum(float(w.get("volume_kg", 0.0)) for w in strength), 1)
+
+
+class StressBudgetEngine:
+    """Allocate weekly stress budget by readiness and phase."""
+
+    def compute(self, context: GlobalTrainingContext) -> WeeklyStressBudget:
+        readiness = context.readiness_score
+        base = max(40.0, context.historical_weekly_load or 80.0)
+        if readiness >= 0.7:
+            total = base * 1.1
+        elif readiness >= 0.4:
+            total = base * 0.95
+        else:
+            total = base * 0.75
+        phase_split = {"build": 0.55, "peak": 0.65, "deload": 0.45}.get(context.goal_phase, 0.55)
+        if readiness < 0.4:
+            phase_split = min(phase_split, 0.50)
+        run_target = total * phase_split
+        strength_target = total - run_target
+        flag_count = len(context.insufficient_data_flags)
+        confidence = max(0.2, min(1.0, 0.95 - (0.15 * flag_count)))
+        return WeeklyStressBudget(
+            target=round(total, 1),
+            minimum=round(total * 0.85, 1),
+            maximum=round(total * 1.15, 1),
+            run_target=round(run_target, 1),
+            strength_target=round(strength_target, 1),
+            confidence=round(confidence, 2),
+            insufficient_data_flags=context.insufficient_data_flags,
+        )
 
 
 @dataclass(frozen=True)
@@ -69,22 +172,32 @@ class PlanDecisionTrace:
 class UnifiedLoadCoordinator:
     """Phase 0 skeleton for the unified planner load coordinator."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, context_assembler: Optional[ContextAssembler] = None, stress_budget_engine: Optional[StressBudgetEngine] = None) -> None:
         self._decision_trace: List[PlanDecisionTrace] = []
+        self._context_assembler = context_assembler
+        self._stress_budget_engine = stress_budget_engine or StressBudgetEngine()
 
     @property
     def decision_trace(self) -> Sequence[PlanDecisionTrace]:
         return tuple(self._decision_trace)
 
-    def assemble_context(self, *, plan_start_date: date, week_number: int) -> GlobalTrainingContext:
+    def assemble_context(self, *, plan_start_date: date, week_number: int, goal_phase: str = "build") -> GlobalTrainingContext:
         """Build minimal global context for a planning week."""
 
-        context = GlobalTrainingContext(
-            plan_start_date=plan_start_date,
-            week_number=week_number,
-            readiness_score=0.5,
-            historical_weekly_load=0.0,
-            constraints=SessionConstraintSet(max_sessions=5, min_recovery_days=1),
+        context = (
+            self._context_assembler.assemble(
+                plan_start_date=plan_start_date,
+                week_number=week_number,
+                goal_phase=goal_phase,
+            )
+            if self._context_assembler
+            else GlobalTrainingContext(
+                plan_start_date=plan_start_date,
+                week_number=week_number,
+                readiness_score=0.5,
+                historical_weekly_load=80.0,
+                constraints=SessionConstraintSet(max_sessions=5, min_recovery_days=1),
+            )
         )
         self._emit_trace(
             PlanDecisionTrace(
@@ -92,7 +205,7 @@ class UnifiedLoadCoordinator:
                 stage="assemble_context",
                 reason_code=PlanDecisionReasonCode.CONTEXT_ASSEMBLED,
                 detail="Created baseline planning context.",
-                payload={"readiness_score": context.readiness_score},
+                payload={"readiness_score": context.readiness_score, "insufficient_data_flags": list(context.insufficient_data_flags)},
             )
         )
         return context
@@ -100,7 +213,7 @@ class UnifiedLoadCoordinator:
     def compute_budget(self, context: GlobalTrainingContext) -> WeeklyStressBudget:
         """Compute initial stress budget from the global context."""
 
-        budget = WeeklyStressBudget(target=100.0, minimum=75.0, maximum=125.0)
+        budget = self._stress_budget_engine.compute(context)
         self._emit_trace(
             PlanDecisionTrace(
                 week_number=context.week_number,

--- a/tests/domain/test_unified_load_coordinator.py
+++ b/tests/domain/test_unified_load_coordinator.py
@@ -3,65 +3,76 @@ from __future__ import annotations
 from datetime import date
 
 from pete_e.domain.unified_load_coordinator import (
-    GlobalTrainingContext,
-    PlanDecisionReasonCode,
-    PlanDecisionTrace,
-    SessionConstraintSet,
+    ContextAssembler,
+    StressBudgetEngine,
     UnifiedLoadCoordinator,
-    WeeklyStressBudget,
 )
 
 
-def test_domain_models_store_expected_values() -> None:
-    constraints = SessionConstraintSet(max_sessions=4, min_recovery_days=2, disallowed_days=(0,))
-    context = GlobalTrainingContext(
-        plan_start_date=date(2026, 5, 4),
-        week_number=2,
-        readiness_score=0.7,
-        historical_weekly_load=92.5,
-        constraints=constraints,
-    )
-    budget = WeeklyStressBudget(target=110.0, minimum=90.0, maximum=130.0)
+class StubDal:
+    def __init__(self, readiness: float, sparse: bool = False) -> None:
+        self._readiness = readiness
+        self._sparse = sparse
 
-    assert context.constraints.max_sessions == 4
-    assert context.readiness_score == 0.7
-    assert budget.maximum == 130.0
+    def get_latest_training_maxes(self):
+        return {} if self._sparse else {"squat": 140.0, "bench": 100.0}
+
+    def get_recent_running_workouts(self, *, days: int, end_date: date):
+        if self._sparse:
+            return []
+        return [
+            {"duration_sec": 2400, "total_distance_km": 5.0},
+            {"duration_sec": 3600, "total_distance_km": 8.0},
+        ]
+
+    def get_historical_metrics(self, days: int):
+        if self._sparse:
+            return []
+        score = self._readiness * 100.0
+        return [{"hrv_recovery_score": score, "body_battery": score} for _ in range(14)]
+
+    def get_recent_strength_workouts(self, *, days: int, end_date: date):
+        if self._sparse:
+            return []
+        return [
+            {"volume_kg": 5000.0},
+            {"volume_kg": 4500.0},
+        ]
+
+    def get_recent_adherence_signal(self, *, days: int, end_date: date):
+        return 0.9
 
 
-def test_plan_decision_trace_serialization_contract() -> None:
-    trace = PlanDecisionTrace(
-        week_number=1,
-        stage="compute_budget",
-        reason_code=PlanDecisionReasonCode.BUDGET_COMPUTED,
-        detail="Budget generated.",
-        payload={"target": 100.0},
-    )
-
-    assert trace.to_dict() == {
-        "week_number": 1,
-        "stage": "compute_budget",
-        "reason_code": "budget_computed",
-        "detail": "Budget generated.",
-        "payload": {"target": 100.0},
-    }
-
-
-def test_coordinator_emits_trace_across_phase0_pipeline(caplog) -> None:
-    caplog.set_level("INFO", logger="pete_e.domain")
-    coordinator = UnifiedLoadCoordinator()
-
-    context = coordinator.assemble_context(plan_start_date=date(2026, 5, 4), week_number=1)
+def _compute_budget(readiness: float, sparse: bool = False):
+    assembler = ContextAssembler(StubDal(readiness=readiness, sparse=sparse))
+    coordinator = UnifiedLoadCoordinator(context_assembler=assembler, stress_budget_engine=StressBudgetEngine())
+    context = coordinator.assemble_context(plan_start_date=date(2026, 5, 4), week_number=1, goal_phase="build")
     budget = coordinator.compute_budget(context)
-    candidates = coordinator.generate_candidates(context, budget)
-    feasible = coordinator.apply_constraints(context, candidates)
-    finalized = coordinator.finalize_week(context, feasible)
+    return context, budget
 
-    assert finalized == []
-    assert [trace.reason_code for trace in coordinator.decision_trace] == [
-        PlanDecisionReasonCode.CONTEXT_ASSEMBLED,
-        PlanDecisionReasonCode.BUDGET_COMPUTED,
-        PlanDecisionReasonCode.CANDIDATE_GENERATED,
-        PlanDecisionReasonCode.CONSTRAINT_APPLIED,
-        PlanDecisionReasonCode.WEEK_FINALIZED,
-    ]
-    assert "plan_decision_trace=" in caplog.text
+
+def test_green_readiness_budget() -> None:
+    _, budget = _compute_budget(0.8)
+    assert budget.target > 70
+    assert budget.run_target > budget.strength_target
+    assert budget.confidence >= 0.8
+
+
+def test_amber_readiness_budget() -> None:
+    _, budget = _compute_budget(0.55)
+    assert budget.target > 60
+    assert budget.minimum < budget.target < budget.maximum
+
+
+def test_red_readiness_budget() -> None:
+    _, budget = _compute_budget(0.25)
+    assert budget.target < 80
+    assert budget.run_target <= budget.target * 0.51
+
+
+def test_sparse_data_mode_sets_flags_and_lower_confidence() -> None:
+    context, budget = _compute_budget(0.5, sparse=True)
+    assert context.insufficient_data_flags
+    assert "missing_training_maxes" in context.insufficient_data_flags
+    assert budget.insufficient_data_flags == context.insufficient_data_flags
+    assert budget.confidence < 0.8


### PR DESCRIPTION
### Motivation
- Introduce Phase 1 of the unified planner to collect richer planning inputs and produce an actionable weekly stress budget that splits run vs strength load. 
- Provide explicit confidence and sparse-data flags to make budgeting behavior auditable and testable.
- Prepare the coordinator to accept assembled context and a budget engine so later phases can build on the same interfaces.

### Description
- Added `ContextAssembler` which collects planning inputs from a DAL-like collaborator (training maxes, recent running workouts, historical health/readiness metrics, recent strength workouts/workload, and an optional adherence signal) and synthesizes `GlobalTrainingContext` including `insufficient_data_flags` and a derived `readiness_score` (see `pete_e/domain/unified_load_coordinator.py`).
- Added `StressBudgetEngine` which computes `WeeklyStressBudget` (target/minimum/maximum), splits `run_target` vs `strength_target` according to readiness + `goal_phase`, and emits `confidence` and `insufficient_data_flags` (see `pete_e/domain/unified_load_coordinator.py`).
- Wired the new components into `UnifiedLoadCoordinator` so `assemble_context` will use `ContextAssembler` (when injected) and `compute_budget` will use `StressBudgetEngine`, and augmented trace payloads to include sparse-data metadata (see `pete_e/domain/unified_load_coordinator.py`).
- Updated the DAL interface stubs to support Phase 1 inputs with default implementations for `get_recent_strength_workload`, `get_latest_training_maxes`, and `get_recent_adherence_signal` to avoid breaking callers (see `pete_e/domain/data_access.py`).
- Replaced the previous Phase 0 coordinator tests with Phase 1 focused tests in `tests/domain/test_unified_load_coordinator.py` that validate budget outputs for green/amber/red readiness and a sparse-data scenario.
- Files changed: `pete_e/domain/unified_load_coordinator.py`, `pete_e/domain/data_access.py`, `tests/domain/test_unified_load_coordinator.py`.

DAL / schema map
- DAL interface additions (interface-only, no DB migrations): added `get_recent_strength_workload(...) -> float`, `get_latest_training_maxes(...) -> Dict[str, Optional[float]]`, and `get_recent_adherence_signal(...) -> Optional[float]` as default/no-op methods on the `DataAccessLayer` contract (implemented in `pete_e/domain/data_access.py`).
- No database schema changes or migrations were added in this phase.

### Testing
- Ran `pytest -q tests/domain/test_unified_load_coordinator.py` which executed the new Phase 1 tests and they all passed (4 passed).
- The tests validate budget behavior for high/medium/low readiness and sparse-data mode (flags + reduced confidence).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fedb552994832fb74edb10bc335b31)