### PR TITLE
Refine unified planner boundaries and remove legacy DAL entrypoint

### DIFF
--- a/pete_e/application/progression_service.py
+++ b/pete_e/application/progression_service.py
@@ -41,7 +41,7 @@ class ProgressionService:
         *,
         persist: bool = True,
     ) -> PlanProgressionDecision:
-        rows = self._dal.get_plan_week(plan_id, week_number)
+        rows = self._dal.get_plan_week_rows(plan_id, week_number)
         if not rows:
             return PlanProgressionDecision(notes=[], updates=[], persisted=False)
 

--- a/pete_e/application/services.py
+++ b/pete_e/application/services.py
@@ -45,7 +45,7 @@ class PlanService:
         running_goal = self._running_goal_from_settings()
         
         # 2. Use PlanFactory to build the plan dictionary
-        plan_dict = self.factory.create_531_block_plan(
+        plan_dict = self.factory.create_unified_531_block_plan(
             start_date,
             tms,
             running_goal=running_goal,

--- a/pete_e/domain/data_access.py
+++ b/pete_e/domain/data_access.py
@@ -236,9 +236,9 @@ class DataAccessLayer(ABC):
         """Perform get active plan."""
 
     @abstractmethod
-    def get_plan_week(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:
+    def get_plan_week_rows(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:
         pass
-        """Perform get plan week."""
+        """Perform get plan week rows."""
 
     @abstractmethod
     def update_workout_targets(self, updates: List[Dict[str, Any]]) -> None:

--- a/pete_e/domain/plan_factory.py
+++ b/pete_e/domain/plan_factory.py
@@ -63,7 +63,7 @@ class PlanFactory:
         )
         """Perform workout sort key."""
 
-    def create_531_block_plan(
+    def create_unified_531_block_plan(
         self,
         start_date: date,
         training_maxes: Dict[str, float],
@@ -72,11 +72,7 @@ class PlanFactory:
         health_metrics: List[Dict[str, Any]] | None = None,
         recent_runs: List[Dict[str, Any]] | None = None,
     ) -> Dict[str, Any]:
-        """
-        Builds a 4-week, 5/3/1 training block. Returns a structured dictionary
-        representing the full plan, ready for persistence.
-        (Logic migrated from plan_builder.py and orchestrator.py)
-        """
+        """Build a 4-week 5/3/1 block via the unified coordinator."""
         weeks_in_plan = 4
         plan_weeks: List[Dict[str, Any]] = []
         trace_by_week: Dict[str, List[Dict[str, Any]]] = {}
@@ -159,14 +155,15 @@ class PlanFactory:
             )
             strength_candidates = [self._strength_candidate_from_workout(item) for item in week_workouts if not item.get("is_cardio")]
             run_candidates = [self._run_candidate_from_workout(item) for item in run_workouts]
-            context = GlobalTrainingContext(
+            context = self.unified_load_coordinator.assemble_context(
                 plan_start_date=start_date,
                 week_number=week_num,
-                readiness_score=0.5,
-                historical_weekly_load=80.0,
-                constraints=SessionConstraintSet(max_sessions=64, min_recovery_days=1),
+                goal_phase="deload" if is_deload_week else "build",
             )
-            budget = WeeklyStressBudget(target=80.0, minimum=65.0, maximum=100.0, run_target=42.0, strength_target=38.0, confidence=0.7)
+            context = GlobalTrainingContext(
+                **{**context.__dict__, "constraints": SessionConstraintSet(max_sessions=64, min_recovery_days=1)}
+            )
+            budget = self.unified_load_coordinator.compute_budget(context)
             candidates = self.unified_load_coordinator.generate_candidates(context, budget, strength_candidates=strength_candidates, run_candidates=run_candidates)
             feasible = self.unified_load_coordinator.apply_constraints(context, candidates)
             finalized = self.unified_load_coordinator.finalize_week(context, feasible, budget)
@@ -206,6 +203,24 @@ class PlanFactory:
                 "plan_decision_trace": trace_by_week,
             },
         }
+
+    def create_531_block_plan(
+        self,
+        start_date: date,
+        training_maxes: Dict[str, float],
+        *,
+        running_goal: RunningGoal | None = None,
+        health_metrics: List[Dict[str, Any]] | None = None,
+        recent_runs: List[Dict[str, Any]] | None = None,
+    ) -> Dict[str, Any]:
+        """Backward-compatible alias for unified 5/3/1 block planning."""
+        return self.create_unified_531_block_plan(
+            start_date,
+            training_maxes,
+            running_goal=running_goal,
+            health_metrics=health_metrics,
+            recent_runs=recent_runs,
+        )
 
     def _strength_candidate_from_workout(self, workout: Dict[str, Any]) -> Dict[str, Any]:
         lift = schedule_rules.LIFT_CODE_BY_ID.get(workout.get("exercise_id"), "")

--- a/pete_e/infrastructure/postgres_dal.py
+++ b/pete_e/infrastructure/postgres_dal.py
@@ -380,10 +380,6 @@ class PostgresDal(PlanRepository):
         return [item for item in traces if isinstance(item, dict)]
         """Perform get plan decision trace."""
 
-    def get_plan_week(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:
-        """Compatibility wrapper for callers expecting the legacy DAL name."""
-        return self.get_plan_week_rows(plan_id, week_number)
-
     def get_plan_for_day(self, target_date: date) -> Tuple[List[str], List[Tuple[Any, ...]]]:
         return self._call_function("sp_plan_for_day", target_date)
         """Perform get plan for day."""

--- a/tests/mock_dal.py
+++ b/tests/mock_dal.py
@@ -259,7 +259,7 @@ class MockableDal(DataAccessLayer):
         return None
         """Perform get active plan."""
 
-    def get_plan_week(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:
+    def get_plan_week_rows(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:
         return []
         """Perform get plan week."""
 

--- a/tests/service/test_progression_service_with_mocked_ports.py
+++ b/tests/service/test_progression_service_with_mocked_ports.py
@@ -22,7 +22,7 @@ class StubDal:
         self.loaded_ids: List[List[int]] = []
         """Implement the `__post_init__` dunder method behavior."""
 
-    def get_plan_week(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:  # noqa: ARG002
+    def get_plan_week_rows(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:  # noqa: ARG002
         return list(self.plan_rows)
         """Perform get plan week."""
 


### PR DESCRIPTION
### Motivation
- Consolidate the planner surface onto the unified coordinator and remove legacy DAL naming that encouraged the split flow.
- Tighten interfaces and call sites so planning entrypoints are explicitly globally-aware by default.
- Reduce adapter/compatibility surface and update tests/mocks to the new names to avoid accidental use of legacy paths.

### Description
- Replaced legacy DAL method name `get_plan_week` with `get_plan_week_rows` across the `DataAccessLayer` abstract interface, `PostgresDal`, service call-sites, and test doubles to standardize row-level access.
- Removed the `PostgresDal.get_plan_week` compatibility wrapper (legacy split-flow naming) and updated callers to the new `get_plan_week_rows` method.
- Made unified planning the explicit primary API in `PlanFactory` by introducing `create_unified_531_block_plan` and changed `PlanService` to call it; kept a thin backward-compatible alias `create_531_block_plan` that delegates to the unified entrypoint.
- Switched per-week context/budget creation in the 5/3/1 builder to use `UnifiedLoadCoordinator.assemble_context` / `compute_budget`, ensuring coordinator-driven (globally aware) defaults are used during candidate generation and finalization.

### Testing
- Ran `pytest -q tests/domain/test_unified_load_coordinator.py tests/domain/test_unified_planner_e2e.py tests/test_plan_service.py tests/service/test_progression_service_with_mocked_ports.py` and all tests passed (`16 passed`).
- Ran `python -m pytest -q tests/test_plan_generation.py tests/test_plan_validation_structure.py` and both suites passed (`8 passed`).
- Updated and executed unit tests that exercise DAL mocks and progression service usage to confirm interface rename; the test changes passed.

Deleted modules/tests
- No files or test modules were deleted in this pass; only the legacy DAL compatibility method was removed: `PostgresDal.get_plan_week` (compat wrapper).

Retained core modules
- `pete_e/domain/unified_load_coordinator.py` (planner context, budget, constraints, trace).
- `pete_e/domain/plan_factory.py` (plan assembly and unified coordinator orchestration).
- `pete_e/domain/running_planner.py` (running session candidate generation).
- `pete_e/application/services.py` (`PlanService` entrypoint and persistence orchestration).
- `pete_e/infrastructure/postgres_dal.py` (DAL implementation, now standardized on `get_plan_week_rows`).

New mental model (end-to-end)
1. `PlanService.create_and_persist_531_block` is the single application entrypoint for block plan creation and persistence.
2. The service calls `PlanFactory.create_unified_531_block_plan`, which assembles raw strength + run session candidates for each week.
3. `UnifiedLoadCoordinator` assembles a global week `GlobalTrainingContext` and computes a `WeeklyStressBudget` based on readiness/phase.
4. The coordinator generates integrated candidates, applies deterministic constraints, finalizes the week, and returns finalized workouts plus a decision trace that is persisted with the plan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee8e3f448832f9b5fed578c0fee0d)