### PR TITLE
Infer lower-body strength sessions by lift name for long-run constraint

### DIFF
--- a/pete_e/domain/unified_load_coordinator.py
+++ b/pete_e/domain/unified_load_coordinator.py
@@ -282,7 +282,16 @@ class UnifiedLoadCoordinator:
 
     def _apply_long_run_vs_lower_strength_volume(self, context: GlobalTrainingContext, sessions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         long_run = next((s for s in sessions if s.get("session_type") == "long_run"), None)
-        lower_strength = [s for s in sessions if s.get("session_type") == "strength" and s.get("lower_body") is True]
+        lower_body_lifts = {"squat", "deadlift", "front_squat", "romanian_deadlift", "rdl", "lunge", "split_squat", "leg_press"}
+        lower_strength = [
+            s
+            for s in sessions
+            if s.get("session_type") == "strength"
+            and (
+                s.get("lower_body") is True
+                or str(s.get("lift", "")).strip().lower() in lower_body_lifts
+            )
+        ]
         if not long_run or not lower_strength:
             return sessions
         if float(long_run.get("stress", 0.0)) < 8.0:

--- a/tests/domain/test_unified_load_coordinator.py
+++ b/tests/domain/test_unified_load_coordinator.py
@@ -96,6 +96,17 @@ def test_constraint_long_run_reduces_lower_body_volume() -> None:
     assert lower["volume_sets"] == 4
     assert any(t.stage == "constraint_long_run_lower_strength" for t in coordinator.decision_trace)
 
+def test_constraint_long_run_infers_lower_body_from_lift_name() -> None:
+    coordinator, context = _context(0.8)
+    candidates = [
+        {"session_type": "long_run", "day_of_week": 6, "stress": 9.0},
+        {"session_type": "strength", "lift": "squat", "volume_sets": 6, "stress": 8.0},
+    ]
+    feasible = coordinator.apply_constraints(context, candidates)
+    lower = next(s for s in feasible if s["session_type"] == "strength")
+    assert lower["volume_sets"] == 4
+    assert any(t.stage == "constraint_long_run_lower_strength" for t in coordinator.decision_trace)
+
 
 def test_constraint_heavy_strength_week_downgrades_run_quality() -> None:
     coordinator, context = _context(0.8)


### PR DESCRIPTION
### Motivation
- The long-run vs lower-body strength constraint only fired when sessions had `lower_body=True`, which missed realistic strength candidates labeled by `lift` names like `squat` or `deadlift`.
- Acceptance scenarios showed marathon-focused weeks could fail to trim lower-body volume when input data omitted the explicit `lower_body` marker.

### Description
- Updated `pete_e/domain/unified_load_coordinator.py` to detect lower-body strength sessions by checking a `lower_body_lifts` set of common lift names in addition to the `lower_body` flag.
- Changed the lower-strength filtering logic to include sessions whose `lift` (normalized) matches the `lower_body_lifts` set.
- Added `test_constraint_long_run_infers_lower_body_from_lift_name` to `tests/domain/test_unified_load_coordinator.py` to cover the new inference behavior.

### Testing
- Ran the scripted acceptance harness exercising the five requested scenarios (marathon-heavy, recovery-compromised, aggressive run jump, strength-priority, balanced) and captured schedules, budgets, constraints, and recovery actions with expected constraint firings.
- Executed `pytest -q tests/domain/test_unified_load_coordinator.py tests/domain/test_unified_planner_e2e.py` and observed all tests pass (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feeb079afc832fb1b1ab6449ed50a1)