### PR TITLE
Refine morning coaching voice and include yesterday's nutrition recap

### DIFF
--- a/pete_e/application/orchestrator.py
+++ b/pete_e/application/orchestrator.py
@@ -373,9 +373,45 @@ class Orchestrator:
             report_date=target,
             action_date=action_date,
         )
+        nutrition_line = self._build_nutrition_summary_line(target)
         if guidance:
-            return f"{report.rstrip()}\n{guidance}"
+            combined = f"{report.rstrip()}\n\n{guidance}"
+            if nutrition_line:
+                combined = f"{combined}\n\n{nutrition_line}"
+            return combined
+        if nutrition_line:
+            return f"{report.rstrip()}\n\n{nutrition_line}"
         return report
+
+
+    def _build_nutrition_summary_line(self, target_date: date) -> str | None:
+        loader = getattr(self.dal, "get_nutrition_daily_summary", None)
+        if not callable(loader):
+            return None
+
+        try:
+            summary = loader(target_date) or {}
+        except Exception as exc:  # pragma: no cover - defensive guard
+            log_utils.warn(f"Failed to load nutrition summary for {target_date.isoformat()}: {exc}")
+            return None
+
+        meals = int(summary.get("meals_logged") or 0)
+        if meals <= 0:
+            return None
+
+        calories = coerce_decimal_to_float(summary.get("calories_est"))
+        protein = coerce_decimal_to_float(summary.get("protein_g"))
+        carbs = coerce_decimal_to_float(summary.get("carbs_g"))
+        fat = coerce_decimal_to_float(summary.get("fat_g"))
+
+        if None in (calories, protein, carbs, fat):
+            return None
+
+        return (
+            "Yesterday you logged "
+            f"{calories:.0f} kcal with macros at {protein:.0f}g protein, "
+            f"{carbs:.0f}g carbs, and {fat:.0f}g fat."
+        )
 
     def build_trainer_message(self, message_date: date | None = None) -> str:
         """Compose Pierre's trainer check-in for the supplied date."""
@@ -451,7 +487,7 @@ class Orchestrator:
                 adjustment=adjustment,
             )
             if status == "updated":
-                message = f"{message} Wger has been updated for today's session."
+                message = f"{message}\n\nI've sent the updates to Wger for you."
             elif status == "unavailable":
                 message = f"{message} Wger update unavailable; apply this manually today."
             else:

--- a/pete_e/domain/morning_coach.py
+++ b/pete_e/domain/morning_coach.py
@@ -226,20 +226,19 @@ def _build_backoff_message(
     runs: Sequence[_PlanItem],
     adjustment: DailyWgerAdjustment,
 ) -> str:
-    trigger = _trigger_text(adjustment.reasons)
     parts: list[str] = []
 
     if strength and adjustment.adjust_strength:
-        load_changes = _load_change_summary(strength, adjustment.weight_multiplier)
         effort = _effort_adjustment_text(adjustment)
-        if load_changes:
+        readiness = _readiness_reason_sentence(adjustment.reasons)
+        session_name = _session_summary(strength)
+        if readiness:
             parts.append(
-                f"Today's gym adjustment for {_session_summary(strength)}: reduce bar load "
-                f"{_percent_drop(adjustment.weight_multiplier)} ({load_changes}); {effort}"
+                f"{readiness} so we're going to adjust today's {session_name} session. We'll {effort}"
             )
         else:
             parts.append(
-                f"Today's gym adjustment for {_session_summary(strength)}: {effort}"
+                f"We're going to adjust today's {session_name} session. We'll {effort}"
             )
 
     if runs and adjustment.adjust_runs:
@@ -257,7 +256,7 @@ def _build_backoff_message(
             "Readiness adjustment: no programmed session today, so keep it to easy walking or mobility"
         )
 
-    return ". ".join(part.rstrip(".") for part in parts) + f".{trigger}"
+    return ". ".join(part.rstrip(".") for part in parts) + "."
 
 
 def _validation_decision_from_adjustment(
@@ -377,11 +376,13 @@ def _effort_adjustment_text(adjustment: DailyWgerAdjustment) -> str:
     return ", ".join(clauses) + " and keep reps crisp"
 
 
-def _trigger_text(reasons: Sequence[str]) -> str:
-    cleaned = [reason.strip() for reason in reasons if reason and reason.strip()]
+def _readiness_reason_sentence(reasons: Sequence[str]) -> str:
+    cleaned = [reason.strip().rstrip(".") for reason in reasons if reason and reason.strip()]
     if not cleaned:
         return ""
-    return " Trigger: " + "; ".join(cleaned[:2]) + "."
+    if len(cleaned) == 1:
+        return cleaned[0]
+    return f"{cleaned[0]} and {cleaned[1]}"
 
 
 def _percent_drop(multiplier: float) -> str:

--- a/tests/application/test_orchestrator_messages.py
+++ b/tests/application/test_orchestrator_messages.py
@@ -31,6 +31,9 @@ class _SummaryDal:
         pass
         """Perform close."""
 
+    def get_nutrition_daily_summary(self, target_date: date):
+        return {"meals_logged": 0}
+
     def get_historical_data(self, start_date: date, end_date: date):  # pragma: no cover - used in tests
         return []
         """Perform get historical data."""
@@ -257,7 +260,7 @@ def test_get_daily_summary_appends_running_backoff_guidance():
 
     assert result.startswith("rendered-narrative")
     assert "Today's run adjustment for Quality run" in result
-    assert "Wger has been updated for today's session" in result
+    assert "I've sent the updates to Wger for you." in result
     assert export_service.calls
     assert export_service.calls[0]["force_overwrite"] is True
     assert export_service.calls[0]["daily_adjustment"].adjust_runs is True
@@ -277,9 +280,8 @@ def test_get_daily_summary_does_not_label_strength_plan_as_run_adjustment():
 
     assert result.startswith("rendered-narrative")
     assert "Run adjustment" not in result
-    assert "Today's gym adjustment for Deadlifts" in result
-    assert "Deadlifts 120 kg -> 114 kg" in result
-    assert "Wger has been updated for today's session" in result
+    assert "adjust today's Deadlifts & Romanian Deadlift session" in result
+    assert "I've sent the updates to Wger for you." in result
     assert export_service.calls[0]["daily_adjustment"].adjust_strength is True
     """Perform test get daily summary does not label strength plan as run adjustment."""
 
@@ -316,3 +318,25 @@ def test_send_telegram_message_uses_client():
     assert telegram.messages == ["Salut"]
     """Perform test send telegram message uses client."""
 
+
+
+def test_get_daily_summary_includes_nutrition_macro_summary():
+    target_date = date(2026, 5, 14)
+
+    class _NutritionDal(_SummaryDal):
+        def get_nutrition_daily_summary(self, target_date: date):
+            return {
+                "meals_logged": 3,
+                "calories_est": 2450,
+                "protein_g": 180,
+                "carbs_g": 250,
+                "fat_g": 70,
+            }
+
+    dal = _NutritionDal([{"metric_name": "weight", "yesterday_value": 82.0}])
+    builder = _NarrativeBuilder()
+    orch = _orchestrator_for(dal, narrative_builder=builder)
+
+    result = orch.get_daily_summary(target_date=target_date)
+
+    assert "Yesterday you logged 2450 kcal with macros at 180g protein, 250g carbs, and 70g fat." in result


### PR DESCRIPTION
### Motivation
- Make the morning Telegram coach message sound like a human trainer (conversational, directive) rather than a robotic list of triggers. 
- Surface recent nutrition logs (yesterday's calories and macros) in the daily summary now that nutrition data is stored.

### Description
- Reworded the strength back-off guidance in `pete_e/domain/morning_coach.py` to read as trainer-directed sentences (uses a new `_readiness_reason_sentence` helper and removes the terse `Trigger:` suffix). 
- Replaced the robotic Wger confirmation in `pete_e/application/orchestrator.py` with a natural first-person line: `I've sent the updates to Wger for you.`. 
- Added a new `_build_nutrition_summary_line` method in `pete_e/application/orchestrator.py` and integrated it into `get_daily_summary` to append an optional nutrition recap stating yesterday's estimated calories and macros when available. 
- Updated `tests/application/test_orchestrator_messages.py` to expect the new phrasing and added a test for the nutrition macro/calorie summary.

### Testing
- Ran `pytest -q tests/application/test_orchestrator_messages.py` and all tests passed (7 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a7dd13e8832fb1deab185fdfdd7a)