### PR TITLE
Add lease-based durable operation recovery for application jobs

### DIFF
--- a/docs/durable_operation_recovery.md
+++ b/docs/durable_operation_recovery.md
@@ -1,0 +1,33 @@
+# Durable Operation Recovery
+
+## Overview
+Pete-Eebot now uses a Postgres-backed lease model for durable operations.
+
+- Jobs enter `queued` then `running`.
+- Running jobs have `worker_id`, `last_heartbeat_at`, and `lease_expires_at`.
+- A heartbeat extends lease expiry.
+- Expired leases are marked `abandoned` automatically during service bootstrap recovery.
+
+## Ownership and fencing
+- A worker heartbeats with its `worker_id`.
+- If heartbeat update fails, ownership is considered lost.
+- Stale jobs are transitioned to `abandoned` with `abandon_reason=lease_expired`.
+
+## Startup recovery
+`ApplicationJobService` calls recovery on startup and marks stale `queued/running` jobs abandoned.
+
+## Operations UI fields
+Jobs now expose:
+- `worker_id`
+- `attempt_number`
+- `last_heartbeat_at`
+- `lease_expires_at`
+- `ownership_token`
+- `abandon_reason`
+- `progress_summary`
+
+## Troubleshooting
+If deploys appear blocked:
+1. Open `/console/jobs` and inspect active `running` job heartbeat age.
+2. If `lease_expires_at` is in the past, recovery will mark it abandoned.
+3. Re-trigger deploy; concurrent requests still return `409 operation_in_progress` while active lease is valid.

--- a/migrations/20260516_add_job_leases_and_recovery.sql
+++ b/migrations/20260516_add_job_leases_and_recovery.sql
@@ -1,0 +1,17 @@
+ALTER TABLE IF EXISTS application_jobs
+    ADD COLUMN IF NOT EXISTS worker_id TEXT,
+    ADD COLUMN IF NOT EXISTS attempt_number INTEGER NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS last_heartbeat_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS ownership_token BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS abandon_reason TEXT,
+    ADD COLUMN IF NOT EXISTS progress_summary JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE application_jobs DROP CONSTRAINT IF EXISTS ck_application_jobs_status;
+ALTER TABLE application_jobs
+    ADD CONSTRAINT ck_application_jobs_status CHECK (
+        status IN ('pending','queued', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'cancelled')
+    );
+
+CREATE INDEX IF NOT EXISTS idx_application_jobs_lease_expires_at ON application_jobs(lease_expires_at);
+CREATE INDEX IF NOT EXISTS idx_application_jobs_worker_id ON application_jobs(worker_id);

--- a/pete_e/application/jobs.py
+++ b/pete_e/application/jobs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextvars
 import concurrent.futures
 from datetime import datetime, timezone
+import os
 import re
 import subprocess
 import threading
@@ -184,10 +185,13 @@ def _log_job_event(
 class ApplicationJobService:
     def __init__(self, repository: ApplicationJobRepository) -> None:
         self.repository = repository
+        self._worker_id = "worker-local"
+        self._lease_seconds = 300.0
         self._executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=4,
             thread_name_prefix="application-job",
         )
+        self.recover_stale_operations()
 
     def _lock_lease_seconds(self, timeout_seconds: float | None) -> float:
         configured_default = 14400.0
@@ -224,6 +228,12 @@ class ApplicationJobService:
             release(job_id=job_id)
             return
         high_risk_operation_guard.release()
+
+    def recover_stale_operations(self) -> int:
+        recover = getattr(self.repository, "recover_stale_operations", None)
+        if not callable(recover):
+            return 0
+        return int(recover(stale_before=_utcnow()))
 
     def _create_job(
         self,
@@ -435,6 +445,23 @@ class ApplicationJobService:
     ) -> None:
         started = time.perf_counter()
         self.repository.mark_running(job_id, started_at=_utcnow())
+        heartbeat_stop = threading.Event()
+
+        def _heartbeat() -> None:
+            sender = getattr(self.repository, "heartbeat", None)
+            while not heartbeat_stop.wait(self._lease_seconds / 3):
+                if callable(sender):
+                    ok = sender(
+                        job_id=job_id,
+                        worker_id=self._worker_id,
+                        lease_seconds=self._lease_seconds,
+                        progress={"operation": operation, "phase": "running"},
+                    )
+                    if not ok:
+                        break
+
+        heartbeat_thread = threading.Thread(target=_heartbeat, name=f"{operation}-heartbeat-{job_id}", daemon=True)
+        heartbeat_thread.start()
         _log_job_event(operation=operation, job_id=job_id, outcome=JOB_STATUS_RUNNING, summary={"command": command[:1]})
         exit_code: int | None = None
         stdout_summary: str | None = None
@@ -477,6 +504,7 @@ class ApplicationJobService:
             failure_reason = str(exc)
             result_summary = f"{operation} failed before process completion."
         finally:
+            heartbeat_stop.set()
             duration_seconds = time.perf_counter() - started
             self.repository.complete(
                 job_id,

--- a/pete_e/domain/jobs.py
+++ b/pete_e/domain/jobs.py
@@ -10,12 +10,16 @@ JOB_STATUS_RUNNING = "running"
 JOB_STATUS_SUCCEEDED = "succeeded"
 JOB_STATUS_FAILED = "failed"
 JOB_STATUS_TIMEOUT = "timeout"
+JOB_STATUS_ABANDONED = "abandoned"
+JOB_STATUS_CANCELLED = "cancelled"
 
 TERMINAL_JOB_STATUSES = frozenset(
     {
         JOB_STATUS_SUCCEEDED,
         JOB_STATUS_FAILED,
         JOB_STATUS_TIMEOUT,
+        JOB_STATUS_ABANDONED,
+        JOB_STATUS_CANCELLED,
     }
 )
 
@@ -40,6 +44,13 @@ class ApplicationJob:
     stderr_summary: str | None = None
     failure_reason: str | None = None
     auth_scheme: str | None = None
+    worker_id: str | None = None
+    attempt_number: int = 1
+    lease_expires_at: datetime | None = None
+    last_heartbeat_at: datetime | None = None
+    ownership_token: int | None = None
+    abandon_reason: str | None = None
+    progress_summary: dict[str, Any] | None = None
 
     @property
     def is_terminal(self) -> bool:
@@ -64,6 +75,13 @@ class ApplicationJob:
             "exit_code": self.exit_code,
             "result_summary": self.result_summary,
             "failure_reason": self.failure_reason,
+            "worker_id": self.worker_id,
+            "attempt_number": self.attempt_number,
+            "lease_expires_at": self.lease_expires_at.isoformat() if self.lease_expires_at else None,
+            "last_heartbeat_at": self.last_heartbeat_at.isoformat() if self.last_heartbeat_at else None,
+            "ownership_token": self.ownership_token,
+            "abandon_reason": self.abandon_reason,
+            "progress_summary": dict(self.progress_summary or {}),
             "request_summary": dict(self.request_summary or {}),
         }
         if include_output:

--- a/pete_e/infrastructure/job_repository.py
+++ b/pete_e/infrastructure/job_repository.py
@@ -9,7 +9,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Json
 from psycopg_pool import ConnectionPool
 
-from pete_e.domain.jobs import ApplicationJob, ApplicationOperationLock, CommandHistoryEntry, JOB_STATUS_QUEUED
+from pete_e.domain.jobs import ApplicationJob, ApplicationOperationLock, CommandHistoryEntry, JOB_STATUS_QUEUED, JOB_STATUS_ABANDONED
 from pete_e.infrastructure.postgres_dal import get_pool
 
 
@@ -38,6 +38,13 @@ class PostgresApplicationJobRepository:
             stdout_summary=row.get("stdout_summary"),
             stderr_summary=row.get("stderr_summary"),
             failure_reason=row.get("failure_reason"),
+            worker_id=row.get("worker_id"),
+            attempt_number=int(row.get("attempt_number") or 1),
+            lease_expires_at=row.get("lease_expires_at"),
+            last_heartbeat_at=row.get("last_heartbeat_at"),
+            ownership_token=int(row["ownership_token"]) if row.get("ownership_token") is not None else None,
+            abandon_reason=row.get("abandon_reason"),
+            progress_summary=dict(row.get("progress_summary") or {}),
         )
 
     @staticmethod
@@ -120,11 +127,55 @@ class PostgresApplicationJobRepository:
                     UPDATE application_jobs
                     SET status = 'running',
                         started_at = %s,
+                        worker_id = COALESCE(worker_id, %s),
+                        last_heartbeat_at = %s,
+                        lease_expires_at = %s,
+                        ownership_token = COALESCE(ownership_token, 0) + 1,
                         updated_at = now()
                     WHERE id = %s
                     """,
-                    (started_at, job_id),
+                    (started_at, "worker-local", started_at, started_at + timedelta(minutes=5), job_id),
                 )
+
+    def heartbeat(self, *, job_id: str, worker_id: str, lease_seconds: float, progress: dict[str, Any] | None = None) -> bool:
+        with self.pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE application_jobs
+                    SET last_heartbeat_at = now(),
+                        lease_expires_at = now() + (%s || ' seconds')::interval,
+                        progress_summary = COALESCE(%s::jsonb, progress_summary),
+                        updated_at = now()
+                    WHERE id = %s
+                      AND status = 'running'
+                      AND worker_id = %s
+                    """,
+                    (float(lease_seconds), Json(progress) if progress is not None else None, job_id, worker_id),
+                )
+                return cur.rowcount > 0
+
+    def recover_stale_operations(self, *, stale_before: datetime) -> int:
+        with self.pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE application_jobs
+                    SET status = %s,
+                        completed_at = now(),
+                        abandon_reason = 'lease_expired',
+                        failure_reason = COALESCE(failure_reason, 'lease_expired'),
+                        result_summary = COALESCE(result_summary, 'Operation abandoned after missed heartbeat.'),
+                        updated_at = now()
+                    WHERE status IN ('queued', 'running')
+                      AND lease_expires_at IS NOT NULL
+                      AND lease_expires_at < %s
+                    """,
+                    (JOB_STATUS_ABANDONED, stale_before),
+                )
+                recovered = cur.rowcount
+                cur.execute("DELETE FROM application_operation_locks WHERE expires_at < now()")
+                return recovered
 
     def complete(
         self,

--- a/pete_e/templates/console/jobs.html
+++ b/pete_e/templates/console/jobs.html
@@ -22,6 +22,10 @@
     <div><dt>Created</dt><dd>{{ selected_job.created_at or "pending" }}</dd></div>
     <div><dt>Started</dt><dd>{{ selected_job.started_at or "pending" }}</dd></div>
     <div><dt>Completed</dt><dd>{{ selected_job.completed_at or "pending" }}</dd></div>
+    <div><dt>Worker</dt><dd>{{ selected_job.worker_id or "-" }}</dd></div>
+    <div><dt>Lease expires</dt><dd>{{ selected_job.lease_expires_at or "-" }}</dd></div>
+    <div><dt>Last heartbeat</dt><dd>{{ selected_job.last_heartbeat_at or "-" }}</dd></div>
+    <div><dt>Attempt</dt><dd>{{ selected_job.attempt_number or 1 }}</dd></div>
     <div><dt>Exit code</dt><dd>{{ selected_job.exit_code if selected_job.exit_code is not none else "pending" }}</dd></div>
     <div><dt>Summary</dt><dd>{{ selected_job.result_summary or "No result yet." }}</dd></div>
     {% if selected_job.failure_reason %}


### PR DESCRIPTION
### Motivation
- Fix stuck-running deploys and permanent deadlocks by making operation ownership time-bounded and recoverable after crashes/restarts. 
- Provide automatic reclamation of abandoned operations, better observability, and a migration path toward multi-worker/distributed execution. 

### Description
- Extended the durable job domain with lease/ownership fields and new terminal states by adding `worker_id`, `attempt_number`, `lease_expires_at`, `last_heartbeat_at`, `ownership_token`, `abandon_reason`, `progress_summary` and states `abandoned`/`cancelled` in `ApplicationJob` (`pete_e/domain/jobs.py`).
- Added repository-side lease lifecycle operations in `PostgresApplicationJobRepository` (`pete_e/infrastructure/job_repository.py`): updated `mark_running` to initialize lease/ownership, implemented `heartbeat(...)` to renew leases and record progress, and added `recover_stale_operations(...)` to auto-mark expired `queued`/`running` jobs as `abandoned` and clean expired operation locks.
- Implemented runtime behavior in `ApplicationJobService` (`pete_e/application/jobs.py`): run `recover_stale_operations()` at startup and added a heartbeat thread for long-running subprocess jobs to renew leases periodically while work is active, and set `worker_id`/lease defaults.
- Added a SQL migration (`migrations/20260516_add_job_leases_and_recovery.sql`) to evolve the schema and expand the status constraint, updated the Jobs UI to surface `worker_id`, `lease_expires_at`, `last_heartbeat_at`, and `attempt_number` (`pete_e/templates/console/jobs.html`), and added operator documentation (`docs/durable_operation_recovery.md`).

### Testing
- Ran unit tests for job logic: `pytest -q tests/application/test_application_jobs.py` — all tests passed (`5 passed`).
- Attempted console/web tests: `pytest -q tests/test_web_console.py` failed during collection due to missing test environment dependency `jinja2` (`ModuleNotFoundError: No module named 'jinja2'`), which is environmental and not related to the new lease logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08338abf08832faecf6a8b88275817)