### PR TITLE
Add week selector to console plan view and adjust plan context for pre-start weeks

### DIFF
--- a/pete_e/api_routes/web.py
+++ b/pete_e/api_routes/web.py
@@ -895,11 +895,14 @@ def console_status(request: Request):
 
 @router.get("/console/plan")
 def console_plan(request: Request):
+    week_view = _query_value(request, "week", "current").strip().lower()
+    if week_view not in {"current", "next"}:
+        week_view = "current"
     return _render_console(
         request,
         "plan",
         template_name="console/plan.html",
-        context_loader=lambda: {"plan_view": _console_read_model().plan(target_date=_operator_today())},
+        context_loader=lambda: {"plan_view": _console_read_model().plan(target_date=_operator_today(), week_view=week_view)},
     )
 
 

--- a/pete_e/application/api_services.py
+++ b/pete_e/application/api_services.py
@@ -402,6 +402,8 @@ class MetricsService(_DateParserMixin):
         start = converters.to_date(plan.get("start_date"))
         weeks = int(plan.get("weeks") or 0)
         current_week = ((target_date - start).days // 7) + 1 if start else None
+        if isinstance(current_week, int) and current_week < 1:
+            current_week = 1
         deload_due = bool(current_week and current_week % 4 == 0)
         return {
             "date": target_date.isoformat(),

--- a/pete_e/application/web_console.py
+++ b/pete_e/application/web_console.py
@@ -210,18 +210,33 @@ class WebConsoleReadModel:
             "last_sync": sync_outcome,
         }
 
-    def plan(self, *, target_date: date) -> dict[str, Any]:
+    def plan(self, *, target_date: date, week_view: str = "current") -> dict[str, Any]:
         week_start = current_week_start(target_date)
+        selected_view = "next" if str(week_view).strip().lower() == "next" else "current"
+        if selected_view == "next":
+            week_start = week_start + timedelta(days=7)
         context = _safe_load(
-            lambda: self._metrics_service.plan_context(target_date.isoformat()),
+            lambda: self._metrics_service.plan_context(week_start.isoformat()),
             {"active_plan": None, "data_quality": "unavailable"},
         )
+
+        active_plan = context.get("active_plan") if isinstance(context.get("active_plan"), dict) else {}
+        active_plan_start = None
+        if active_plan:
+            raw_start = active_plan.get("start_date")
+            if hasattr(raw_start, "isoformat"):
+                active_plan_start = raw_start
+            elif isinstance(raw_start, str):
+                try:
+                    active_plan_start = date.fromisoformat(raw_start)
+                except ValueError:
+                    active_plan_start = None
+
         week_plan = _safe_load(
             lambda: self._plan_service.for_week(week_start.isoformat()),
             {"columns": [], "rows": [], "status": "unavailable"},
         )
 
-        active_plan = context.get("active_plan") if isinstance(context.get("active_plan"), dict) else {}
         plan_id = active_plan.get("id") if active_plan else None
         week_number = context.get("current_week_number")
         if plan_id and week_number:
@@ -243,6 +258,8 @@ class WebConsoleReadModel:
         return {
             "date": target_date.isoformat(),
             "week_start": week_start.isoformat(),
+            "week_view": selected_view,
+            "is_next_week_available": bool(active_plan_start and week_start < active_plan_start),
             "context": context,
             "week_plan": week_plan,
             "decision_trace": trace,

--- a/pete_e/templates/console/plan.html
+++ b/pete_e/templates/console/plan.html
@@ -6,6 +6,11 @@
   <p class="eyebrow">{{ page.eyebrow }}</p>
   <h1 id="page-title">{{ page.title }}</h1>
   <p class="page-summary">{{ page.summary }}</p>
+  <p>
+    <a href="/console/plan?week=current" {% if plan_view.week_view != "next" %}aria-current="page"{% endif %}>This week</a>
+    ·
+    <a href="/console/plan?week=next" {% if plan_view.week_view == "next" %}aria-current="page"{% endif %}>Next week</a>
+  </p>
 </section>
 
 <section class="panel-grid" aria-label="Current plan sections">
@@ -38,7 +43,7 @@
   </article>
 
   <article class="panel panel-wide">
-    <h2>Current Week Plan</h2>
+    <h2>{% if plan_view.week_view == "next" %}Next Week Plan{% else %}Current Week Plan{% endif %}</h2>
     {% if plan_view.week_plan.error %}
       {{ ui.empty_state(plan_view.week_plan.error) }}
     {% elif plan_view.week_plan.rows %}


### PR DESCRIPTION
### Motivation

- Provide a way to view either the current or next week of the active training plan from the console plan page.
- Ensure plan context reports sane week numbers for dates that fall before a plan's start date.

### Description

- Added query parsing in `console_plan` to accept a `week` parameter (allowed values `current` or `next`) and pass it into the read model. 
- Extended `WebConsoleReadModel.plan` to accept a `week_view` parameter, compute the `week_start` accordingly (advance by 7 days for `next`), and include `week_view` and `is_next_week_available` in the returned view model.
- Hardened `MetricsService.plan_context` to clamp `current_week` to a minimum of `1` when the computed week is less than 1.
- Updated the `console/plan.html` template to render links for `This week` and `Next week`, highlight the active selection with `aria-current`, and adapt the panel title based on the selected view.

### Testing

- Ran the project test suite via `pytest` against the modified code and all tests completed successfully.
- Verified template rendering and the console plan endpoint respond with `week=current` and `week=next` variants in automated view tests (status: pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0996749cc8832f9a3c1dc4571ed2c2)