### PR TITLE
Format week start as DD/MM/YYYY and show workout day names in console plan

### DIFF
--- a/pete_e/application/web_console.py
+++ b/pete_e/application/web_console.py
@@ -58,6 +58,30 @@ def _metric_value(payload: dict[str, Any], key: str) -> Any:
     return entry.get("value")
 
 
+def _coerce_iso_date(value: Any) -> date | None:
+    if hasattr(value, "isoformat") and isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None
+        try:
+            return date.fromisoformat(candidate)
+        except ValueError:
+            return None
+    return None
+
+
+def _format_date_ddmmyyyy(value: Any) -> str:
+    parsed = _coerce_iso_date(value)
+    return parsed.strftime("%d/%m/%Y") if parsed else str(value or "-")
+
+
+def _format_day_name(value: Any) -> str:
+    parsed = _coerce_iso_date(value)
+    return parsed.strftime("%A") if parsed else str(value or "-")
+
+
 _TEXT_LOG_RE = re.compile(r"^\[(?P<timestamp>[^\]]+)\]\s+\[(?P<level>[^\]]+)\]\s+\[(?P<tag>[^\]]+)\]\s+(?P<message>.*)$")
 
 
@@ -257,11 +281,22 @@ class WebConsoleReadModel:
 
         return {
             "date": target_date.isoformat(),
-            "week_start": week_start.isoformat(),
+            "week_start": _format_date_ddmmyyyy(week_start),
             "week_view": selected_view,
             "is_next_week_available": bool(active_plan_start and week_start < active_plan_start),
             "context": context,
-            "week_plan": week_plan,
+            "week_plan": {
+                **week_plan,
+                "rows": [
+                    {
+                        **row,
+                        "workout_date": _format_day_name(row.get("workout_date") or row.get("date")),
+                    }
+                    if isinstance(row, dict)
+                    else row
+                    for row in (week_plan.get("rows") or [])
+                ],
+            },
             "decision_trace": trace,
         }
 

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -482,6 +482,9 @@ def test_plan_page_renders_current_week_plan_and_decision_trace(monkeypatch: pyt
     assert response.status_code == 200
     assert "Current Week Plan" in html
     assert "Bench Press" in html
+    assert "12/05/2026" in html
+    assert "Monday" in html
+    assert "2026-05-12" not in html
     assert "constraint_heavy_strength_run_quality" in html
 
 


### PR DESCRIPTION
### Motivation
- Display dates in the operator console in the requested human-friendly formats so the week start is `DD/MM/YYYY` and the plan table shows day names rather than ISO dates.
- Normalize incoming date-like values so rendering is robust whether services return `date` objects or ISO date strings.

### Description
- Added helper functions ` _coerce_iso_date`, `_format_date_ddmmyyyy`, and `_format_day_name` to `pete_e/application/web_console.py` to parse and format date inputs.
- Replaced the raw ISO output for the plan read-model `week_start` with ` _format_date_ddmmyyyy(week_start)` in `WebConsoleReadModel.plan`.
- Transformed `week_plan` rows so each row's `workout_date` is replaced with the day name via `_format_day_name` before rendering the page.
- Updated `tests/test_web_console.py` to assert the new rendering expectations: presence of `12/05/2026` and `Monday`, and absence of the raw ISO `2026-05-12` in the plan page output.

### Testing
- Ran `pytest -q tests/test_web_console.py::test_plan_page_renders_current_week_plan_and_decision_trace`, which failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'jinja2'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09d8d89f44832f8ad5e424414a68a0)