### PR TITLE
Fallback status sync outcome to durable job records

### DIFF
--- a/pete_e/application/api_services.py
+++ b/pete_e/application/api_services.py
@@ -591,7 +591,7 @@ class StatusService:
         """Perform run checks."""
 
     def last_sync_outcome(self, lines: int = 500) -> Dict[str, Any]:
-        """Return the latest persisted sync summary from the application log."""
+        """Return the latest persisted sync summary from logs or durable sync jobs."""
 
         log_path = settings.log_path
         if not log_path.exists():
@@ -618,12 +618,37 @@ class StatusService:
             if parsed:
                 return parsed
 
+        job_fallback = self._last_sync_outcome_from_jobs()
+        if job_fallback:
+            return job_fallback
+
         return {
             "status": "missing",
             "source_statuses": {},
             "failed_sources": [],
             "message": "No sync summary found in recent logs.",
         }
+
+    def _last_sync_outcome_from_jobs(self) -> Dict[str, Any] | None:
+        """Fallback to the latest completed sync job summary when logs rotate."""
+        list_recent = getattr(self._dal, "list_recent_jobs", None)
+        if not callable(list_recent):
+            return None
+        try:
+            jobs = list_recent(limit=100)
+        except Exception:
+            return None
+        for job in jobs or []:
+            if str(getattr(job, "operation", "")).strip().lower() != "sync":
+                continue
+            summary_text = str(getattr(job, "result_summary", "") or "").strip()
+            if not summary_text:
+                continue
+            parsed = _parse_sync_summary_line(summary_text)
+            if parsed:
+                parsed.setdefault("message", "Recovered from durable sync job record.")
+                return parsed
+        return None
 
 
 _SYNC_SUMMARY_RE = re.compile(

--- a/tests/test_web_console.py
+++ b/tests/test_web_console.py
@@ -818,6 +818,32 @@ def test_status_service_parses_json_sync_summary_without_json_tail(
     }
 
 
+def test_status_service_falls_back_to_latest_sync_job_summary_when_log_missing(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_path = tmp_path / "missing.log"
+    monkeypatch.setattr("pete_e.application.api_services.settings", SimpleNamespace(log_path=log_path))
+
+    class _Job:
+        operation = "sync"
+        result_summary = (
+            "Sync summary: run=daily | days=2 | attempts=1 | result=success | "
+            "AppleDropbox=ok, Withings=ok"
+        )
+
+    class _Dal:
+        @staticmethod
+        def list_recent_jobs(limit: int = 25):
+            return [_Job()]
+
+    payload = StatusService(dal=_Dal()).last_sync_outcome()
+
+    assert payload["status"] == "observed"
+    assert payload["success"] is True
+    assert payload["source_statuses"] == {"AppleDropbox": "ok", "Withings": "ok"}
+
+
 def test_operator_nav_shows_operator_page_but_hides_owner_admin(monkeypatch: pytest.MonkeyPatch) -> None:
     service = _UserService(_user(ROLE_OPERATOR))
     monkeypatch.setattr(dependencies, "get_user_service", lambda: service)


### PR DESCRIPTION
### Motivation
- The status read model could report `missing` when the latest sync summary was not present in recent logs, because `StatusService.last_sync_outcome` only scanned log lines.  
- The goal is to make the last-sync DTO resilient to log rotation/windowing by recovering the same summary from durable job records when available.  

### Description
- Updated `StatusService.last_sync_outcome` in `pete_e/application/api_services.py` to keep a log-first strategy but fall back to a durable job lookup when no parsable sync summary is found.  
- Added a helper `StatusService._last_sync_outcome_from_jobs` that calls the DAL's `list_recent_jobs`, filters for `operation == "sync"`, and parses `result_summary` via the existing `_parse_sync_summary_line`.  
- Added a regression test `test_status_service_falls_back_to_latest_sync_job_summary_when_log_missing` in `tests/test_web_console.py` to validate the fallback path and parsed `source_statuses`.  

### Testing
- Ran `pytest -q tests/test_web_console.py -k "status_service_reads_latest_sync_outcome_from_log or status_service_parses_json_sync_summary_without_json_tail or falls_back_to_latest_sync_job_summary_when_log_missing"` to exercise the log-parse and fallback tests.  
- Test run failed during collection due to a missing test dependency (`jinja2`), so the new fallback test could not execute in this environment.  
- Existing parsing tests remain unchanged and the changes are limited to service read behavior and a single unit test addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f673aff0832f97abf4239f3180b7)