### PR TITLE
Fix config stub exports for settings test collection

### DIFF
--- a/tests/config_stub.py
+++ b/tests/config_stub.py
@@ -147,4 +147,16 @@ config_submodule = types.ModuleType("pete_e.config.config")
 config_submodule.Settings = Settings
 config_submodule.settings = config_module.settings
 config_submodule.get_env = get_env
+
+
+# Keep compatibility with tests that import concrete config symbols.
+config_submodule.CONFIG_FILE = Path(__file__).resolve()
+
+def _discover_project_root(config_file: Path) -> tuple[Path, Path]:
+    project_root = Path(__file__).resolve().parents[1]
+    explicit_env = os.getenv("PETEEEBOT_ENV_FILE")
+    env_file = Path(explicit_env).expanduser().resolve() if explicit_env else project_root / ".env"
+    return project_root, env_file
+
+config_submodule._discover_project_root = _discover_project_root
 sys.modules["pete_e.config.config"] = config_submodule


### PR DESCRIPTION
### Motivation
- Tests import concrete symbols from `pete_e.config.config` during collection and the test stub previously shadowed the real module without exporting `CONFIG_FILE` or `_discover_project_root`, causing import errors. 
- The change ensures the stub matches the production API expected by `tests/config/test_settings.py` and avoids import-order dependent failures.

### Description
- Updated `tests/config_stub.py` to add `config_submodule.CONFIG_FILE = Path(__file__).resolve()` so the stub exposes `CONFIG_FILE`.
- Implemented `_discover_project_root` on the stub and assigned it to `config_submodule._discover_project_root`, and made the implementation honor the `PETEEEBOT_ENV_FILE` environment variable or else fall back to the repository `.env` file.
- Continued to expose `Settings`, `settings`, and `get_env` on the `pete_e.config.config` stub for compatibility with tests.

### Testing
- Ran `pytest -q tests/test_progression.py tests/config/test_settings.py -q`, which passed. 
- Ran a full `pytest -q` which still fails in this environment due to a missing optional dependency (`jinja2`), which is unrelated to the config stub fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f794ee34832f94024449be565f2e)