### PR TITLE
Fix console plan date formatting and sync status fallback

### DIFF
--- a/pete_e/application/api_services.py
+++ b/pete_e/application/api_services.py
@@ -595,6 +595,9 @@ class StatusService:
 
         log_path = settings.log_path
         if not log_path.exists():
+            job_fallback = self._last_sync_outcome_from_jobs()
+            if job_fallback:
+                return job_fallback
             return {
                 "status": "missing",
                 "source_statuses": {},

--- a/pete_e/application/web_console.py
+++ b/pete_e/application/web_console.py
@@ -290,7 +290,7 @@ class WebConsoleReadModel:
                 "rows": [
                     {
                         **row,
-                        "workout_date": _format_day_name(row.get("workout_date") or row.get("date")),
+                        "workout_date": _format_date_ddmmyyyy(row.get("workout_date") or row.get("date")),
                     }
                     if isinstance(row, dict)
                     else row


### PR DESCRIPTION
### Motivation
- Two CI tests failed: `test_plan_page_renders_current_week_plan_and_decision_trace` expected a `dd/mm/yyyy` date in the plan view and `test_status_service_falls_back_to_latest_sync_job_summary_when_log_missing` expected an `observed` sync outcome when logs were unavailable. 
- The intent is to restore the expected date format in the console plan UI and ensure the status service falls back to durable job summaries when the log file is missing.

### Description
- Updated `pete_e/application/web_console.py` to render each plan row `workout_date` with `_format_date_ddmmyyyy(...)` instead of `_format_day_name(...)` so dates appear as `dd/mm/yyyy` in the plan table. 
- Updated `pete_e/application/api_services.py` in `StatusService.last_sync_outcome` to call `_last_sync_outcome_from_jobs()` when `settings.log_path` does not exist and return that fallback if present before returning a `missing` payload.

### Testing
- CI reported 2 failing tests: `tests/test_web_console.py::test_plan_page_renders_current_week_plan_and_decision_trace` and `tests/test_web_console.py::test_status_service_falls_back_to_latest_sync_job_summary_when_log_missing`. 
- I attempted to run the two targeted tests locally with `pytest` but test collection failed with `ModuleNotFoundError: No module named 'jinja2'`, so local automated verification could not complete. 
- After applying the changes the targeted tests were re-run but the local environment lacked `jinja2`, so their pass/fail status remains to be validated in CI with dependencies available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f941948c832f9296184ae9198fa4)