### PR TITLE
Restore day-name labels in weekly plan table

### DIFF
--- a/pete_e/application/web_console.py
+++ b/pete_e/application/web_console.py
@@ -290,7 +290,7 @@ class WebConsoleReadModel:
                 "rows": [
                     {
                         **row,
-                        "workout_date": _format_date_ddmmyyyy(row.get("workout_date") or row.get("date")),
+                        "workout_date": _format_day_name(row.get("workout_date") or row.get("date")),
                     }
                     if isinstance(row, dict)
                     else row

--- a/pete_e/templates/console/plan.html
+++ b/pete_e/templates/console/plan.html
@@ -50,7 +50,7 @@
       <table class="data-table">
         <thead>
           <tr>
-            <th scope="col">Date</th>
+            <th scope="col">Day</th>
             <th scope="col">Exercise</th>
             <th scope="col">Sets</th>
             <th scope="col">Reps</th>


### PR DESCRIPTION
### Motivation
- The weekly plan table had started displaying ISO dates instead of long weekday names; restore the human-friendly day labels (e.g., `Monday`) and make the column label consistent.

### Description
- Use `_format_day_name(...)` to render `workout_date` in `pete_e/application/web_console.py` and update the table header from `Date` to `Day` in `pete_e/templates/console/plan.html`.

### Testing
- Ran `pytest -q tests/test_web_console.py`, which failed at collection due to a missing dependency (`ModuleNotFoundError: No module named 'jinja2'`), so test assertions were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fd54d340832fb6a37a503064ce7d)