### PR TITLE
Harden webhook deploy triggering and deployment locking

### DIFF
--- a/pete_e/api_routes/logs_webhooks.py
+++ b/pete_e/api_routes/logs_webhooks.py
@@ -1,6 +1,7 @@
 import datetime
 import hashlib
 import hmac
+import json
 
 import fastapi
 from fastapi import Header, HTTPException, Query, Request
@@ -59,15 +60,39 @@ async def github_webhook(request: Request):
 
     if getattr(request, "state", None) is not None:
         setattr(request.state, "auth_scheme", "github_webhook_hmac")
+    event_name = request.headers.get("X-GitHub-Event")
+    delivery_id = request.headers.get("X-GitHub-Delivery")
+    payload: dict[str, object] = {}
+    if body:
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = {}
+    commit_sha = str(payload.get("after") or payload.get("head_commit", {}).get("id") or "").strip()
+    ref_name = str(payload.get("ref") or "").strip()
+
     job_id = prepare_job_context(request, "deploy")
-    summary = {"source": "github_webhook"}
+    summary = {
+        "source": "github_webhook",
+        "delivery_id": delivery_id,
+        "event": event_name,
+        "commit_sha": commit_sha,
+        "ref": ref_name,
+    }
     audit_command_event(request, command="deploy", outcome="started", summary=summary)
     try:
         correlation_id = get_or_create_correlation_id(request)
         get_job_service().enqueue_subprocess(
             job_id=job_id,
             operation="deploy",
-            command=[str(configured_deploy_script_path())],
+            command=[
+                "/usr/bin/env",
+                f"WEBHOOK_DELIVERY_ID={delivery_id or ''}",
+                f"GITHUB_EVENT_NAME={event_name or ''}",
+                f"GITHUB_COMMIT_SHA={commit_sha}",
+                f"GITHUB_REF={ref_name}",
+                str(configured_deploy_script_path()),
+            ],
             requester=None,
             request_id=correlation_id,
             correlation_id=correlation_id,
@@ -75,6 +100,26 @@ async def github_webhook(request: Request):
             timeout_seconds=getattr(settings, "PETEEEBOT_PROCESS_TIMEOUT_SECONDS", None),
             auth_scheme=getattr(getattr(request, "state", None), "auth_scheme", None),
         )
+    except HTTPException as exc:
+        detail = getattr(exc, "detail", {})
+        if getattr(exc, "status_code", None) == 409 and isinstance(detail, dict) and detail.get("code") == "operation_in_progress":
+            ignored = {
+                "status": "Deployment already in progress; webhook delivery ignored.",
+                "job_id": job_id,
+                "delivery_id": delivery_id,
+                "commit_sha": commit_sha,
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+            }
+            audit_command_event(request, command="deploy", outcome="succeeded", summary=ignored)
+            return ignored
+        audit_command_event(
+            request,
+            command="deploy",
+            outcome="failed",
+            summary={"status_code": getattr(exc, "status_code", 500), "error": str(getattr(exc, "detail", exc))},
+            level="ERROR",
+        )
+        raise
     except Exception as exc:
         audit_command_event(
             request,

--- a/pete_e/resources/deploy-wrapper.sh
+++ b/pete_e/resources/deploy-wrapper.sh
@@ -10,6 +10,7 @@ SHARED_ROOT="${SHARED_ROOT:-${PROJECT_ROOT}/shared}"
 VENV_ROOT="${VENV_ROOT:-${SHARED_ROOT}/venv}"
 ENV_FILE="${ENV_FILE:-${SHARED_ROOT}/.env}"
 LOGFILE="${LOGFILE:-/var/log/pete_eebot/deploy.log}"
+LOCKFILE="${LOCKFILE:-/var/lock/pete_eebot-deploy.lock}"
 TRACKED_DEPLOY="${TRACKED_DEPLOY:-${APP_ROOT}/pete_e/resources/deploy.sh}"
 export ENV_FILE PETEEEBOT_ENV_FILE="${PETEEEBOT_ENV_FILE:-${ENV_FILE}}"
 
@@ -17,6 +18,15 @@ mkdir -p "$(dirname "${LOGFILE}")"
 exec > >(tee -a "${LOGFILE}") 2>&1
 
 printf '%s\n' "---- Deploy wrapper run at $(date -Is) ----"
+printf '%s\n' "Webhook metadata: delivery=${WEBHOOK_DELIVERY_ID:-unknown} sha=${GITHUB_COMMIT_SHA:-unknown} ref=${GITHUB_REF:-unknown}"
+mkdir -p "$(dirname "${LOCKFILE}")"
+
+exec 9>"${LOCKFILE}"
+if ! flock -n 9; then
+    printf '%s\n' "Deploy already in progress; ignoring duplicate trigger. lock=${LOCKFILE} pid=$$ delivery=${WEBHOOK_DELIVERY_ID:-unknown} sha=${GITHUB_COMMIT_SHA:-unknown}"
+    exit 0
+fi
+printf '%s\n' "Deploy lock acquired. lock=${LOCKFILE} pid=$$"
 
 if [[ ! -d "${APP_ROOT}/.git" ]]; then
     printf '%s\n' "ERROR: Git repository not found at ${APP_ROOT}"
@@ -42,6 +52,11 @@ exec env \
     ENV_FILE="${ENV_FILE}" \
     PETEEEBOT_ENV_FILE="${PETEEEBOT_ENV_FILE}" \
     LOGFILE="${LOGFILE}" \
+    LOCKFILE="${LOCKFILE}" \
+    WEBHOOK_DELIVERY_ID="${WEBHOOK_DELIVERY_ID:-}" \
+    GITHUB_EVENT_NAME="${GITHUB_EVENT_NAME:-}" \
+    GITHUB_COMMIT_SHA="${GITHUB_COMMIT_SHA:-}" \
+    GITHUB_REF="${GITHUB_REF:-}" \
     DEPLOY_LOG_ATTACHED=1 \
     SKIP_GIT_UPDATE=1 \
     bash "${TRACKED_DEPLOY}"

--- a/pete_e/resources/deploy.sh
+++ b/pete_e/resources/deploy.sh
@@ -18,6 +18,7 @@ ENV_FILE="${ENV_FILE:-${SHARED_ROOT}/.env}"
 PYTHON_BIN="${PYTHON_BIN:-${VENV_ROOT}/bin/python3}"
 SERVICE_NAME="${SERVICE_NAME:-peteeebot.service}"
 LOGFILE="${LOGFILE:-/var/log/pete_eebot/deploy.log}"
+LOCKFILE="${LOCKFILE:-/var/lock/pete_eebot-deploy.lock}"
 SKIP_GIT_UPDATE="${SKIP_GIT_UPDATE:-0}"
 export ENV_FILE PETEEEBOT_ENV_FILE="${PETEEEBOT_ENV_FILE:-${ENV_FILE}}"
 
@@ -67,7 +68,17 @@ on_error() {
 
 trap on_error ERR
 
-log "---- Deploy run at $(date -Is) ----"
+DEPLOY_PID="$$"
+DEPLOY_START_AT="$(date -Is)"
+log "---- Deploy run at ${DEPLOY_START_AT} ----"
+log "Deploy metadata: pid=${DEPLOY_PID} delivery=${WEBHOOK_DELIVERY_ID:-unknown} sha=${GITHUB_COMMIT_SHA:-unknown} event=${GITHUB_EVENT_NAME:-unknown} ref=${GITHUB_REF:-unknown}"
+mkdir -p "$(dirname "${LOCKFILE}")"
+exec 9>"${LOCKFILE}"
+if ! flock -n 9; then
+    log "Deploy already in progress; ignoring duplicate trigger. lock=${LOCKFILE} pid=${DEPLOY_PID} delivery=${WEBHOOK_DELIVERY_ID:-unknown} sha=${GITHUB_COMMIT_SHA:-unknown}"
+    exit 0
+fi
+log "Deploy lock acquired. lock=${LOCKFILE} pid=${DEPLOY_PID}"
 
 [[ -d "${APP_ROOT}/.git" ]] || fail "Git repository not found at ${APP_ROOT}"
 [[ -x "${PYTHON_BIN}" ]] || fail "Python venv not found at ${PYTHON_BIN}"
@@ -107,4 +118,5 @@ notify_telegram "Deploy installed on $(hostname): ${COMMIT_INFO}. Restarting ${S
 log "Restarting ${SERVICE_NAME}..."
 restart_service
 
-log "Deploy completed successfully at $(date -Is)"
+DEPLOY_END_AT="$(date -Is)"
+log "Deploy completed successfully at ${DEPLOY_END_AT} (pid=${DEPLOY_PID}, delivery=${WEBHOOK_DELIVERY_ID:-unknown}, sha=${GITHUB_COMMIT_SHA:-unknown})"


### PR DESCRIPTION
### Motivation
- Prevent duplicate or overlapping deployments caused by GitHub webhook retries and long-running synchronous deploy executions. 
- Ensure webhook deliveries return quickly while moving the actual deploy work into a safe asynchronous flow with cross-process protection. 
- Improve observability so webhook delivery IDs and commit SHAs can be correlated with deployment runs and logs. 

### Description
- Enriched the `/webhook` handler to parse and record GitHub metadata (`X-GitHub-Delivery`, `X-GitHub-Event`, payload `after`/`ref`) and include it in the job audit summary. 
- Propagated webhook metadata into the deploy invocation by passing environment variables (`WEBHOOK_DELIVERY_ID`, `GITHUB_EVENT_NAME`, `GITHUB_COMMIT_SHA`, `GITHUB_REF`) to the tracked deploy script. 
- Made duplicate-delivery handling idempotent by catching `operation_in_progress` (409) from the job service and returning a graceful ignored-success response instead of surfacing an error. 
- Added OS-level non-blocking locks using `flock` in both the stable wrapper (`pete_e/resources/deploy-wrapper.sh`) and the tracked deploy script (`pete_e/resources/deploy.sh`), and emitted logs for lock acquisition, PID, delivery id, commit sha, and start/end timestamps. 

### Testing
- Compiled Python webhook module with `python -m py_compile pete_e/api_routes/logs_webhooks.py` which succeeded. 
- Performed shell syntax checks with `bash -n pete_e/resources/deploy-wrapper.sh pete_e/resources/deploy.sh` which succeeded. 
- Ran `pytest -q tests/test_api_hardening.py` which failed during collection in this environment due to a missing test dependency (`jinja2`) and is not indicative of the patch behavior on a production host where dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1d84cc70832f88367efc58424381)