### PR TITLE
Prune stale high-risk operation lock blocking deploy retries

### DIFF
--- a/pete_e/infrastructure/job_repository.py
+++ b/pete_e/infrastructure/job_repository.py
@@ -375,6 +375,7 @@ class PostgresApplicationJobRepository:
         expires_at = now + timedelta(seconds=max(60.0, float(lease_seconds)))
         with self.pool.connection() as conn:
             with conn.cursor(row_factory=dict_row) as cur:
+                self._prune_orphaned_high_risk_lock(cur)
                 cur.execute(
                     """
                     DELETE FROM application_operation_locks
@@ -401,6 +402,22 @@ class PostgresApplicationJobRepository:
                 row = cur.fetchone()
         return self._lock_from_row(row) if row else None
 
+    @staticmethod
+    def _prune_orphaned_high_risk_lock(cur) -> None:
+        cur.execute(
+            """
+            DELETE FROM application_operation_locks l
+            WHERE l.lock_name = 'high_risk_operation'
+              AND l.job_id IS NOT NULL
+              AND EXISTS (
+                  SELECT 1
+                  FROM application_jobs j
+                  WHERE j.id = l.job_id
+                    AND j.status NOT IN ('queued', 'running')
+              )
+            """
+        )
+
     def release_high_risk_operation_lock(self, *, job_id: str) -> None:
         with self.pool.connection() as conn:
             with conn.cursor() as cur:
@@ -416,6 +433,7 @@ class PostgresApplicationJobRepository:
     def get_active_high_risk_operation_lock(self) -> ApplicationOperationLock | None:
         with self.pool.connection() as conn:
             with conn.cursor(row_factory=dict_row) as cur:
+                self._prune_orphaned_high_risk_lock(cur)
                 cur.execute(
                     """
                     SELECT *


### PR DESCRIPTION
### Motivation

- Deploy triggers could return "Cannot start deploy; deploy is already running." while `/console/jobs` showed no running jobs due to orphaned `application_operation_locks` rows referencing terminal jobs. This change aims to remove those stale locks so deploy retries are not falsely blocked.

### Description

- Added a new helper `PostgresApplicationJobRepository._prune_orphaned_high_risk_lock(cur)` that deletes `high_risk_operation` lock rows whose `job_id` points to a job that is no longer `queued` or `running`.
- Call the pruning helper before attempting to acquire the `high_risk_operation` lock in `acquire_high_risk_operation_lock()` so stale rows are removed prior to insertion attempts.
- Call the pruning helper before reading the active lock in `get_active_high_risk_operation_lock()` so the API reports no active lock when the linked job is terminal.
- Preserves existing lease-expiry behavior; this is an additional safeguard for mismatch scenarios where lock rows outlive their job records.

### Testing

- Ran `pytest -q tests/application/test_application_jobs.py` and it passed (`5 passed`).
- Attempted `pytest -q tests/test_api_concurrency_guard.py` but collection failed in this environment with `ModuleNotFoundError: No module named 'jinja2'`, so that test file could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a216f1174832f8bd7888bed3ac92b)